### PR TITLE
feat(theme): add --header CSS variable for conditional header background

### DIFF
--- a/app/board/[id]/BoardPageClient.tsx
+++ b/app/board/[id]/BoardPageClient.tsx
@@ -227,9 +227,9 @@ export const BoardPageClient = memo(function BoardPageClient({
     <>
       <main className="flex h-screen flex-col">
         {/* Header */}
-        <header className="border-b border-gray-200 bg-white px-6 py-4 dark:border-gray-700 dark:bg-gray-800">
+        <header className="border-b border-header-border bg-header px-6 py-4">
           <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            <h1 className="text-2xl font-bold text-header-foreground">
               {boardSettings.displayName}
             </h1>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,6 +57,9 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+  --color-header: var(--header);
+  --color-header-foreground: var(--header-foreground);
+  --color-header-border: var(--header-border);
   --color-brand: var(--brand);
   --color-highlight: var(--highlight);
 }
@@ -96,6 +99,9 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --header: var(--sidebar);
+  --header-foreground: var(--sidebar-foreground);
+  --header-border: var(--sidebar-border);
   --highlight: oklch(0.852 0.199 91.936);
   --brand: oklch(0.623 0.214 259.815);
 }
@@ -134,6 +140,9 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --header: var(--sidebar);
+  --header-foreground: var(--sidebar-foreground);
+  --header-border: var(--sidebar-border);
   --highlight: oklch(0.852 0.199 91.936);
   --brand: oklch(0.707 0.165 254.624);
 }

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -33,6 +33,9 @@
   --border: oklch(0.86 0.018 80);
   --input: oklch(0.88 0.015 80);
   --ring: oklch(0.6 0.02 75);
+  --header: #ffffff;
+  --header-foreground: oklch(0.18 0.01 70);
+  --header-border: oklch(0.86 0.018 80);
   --theme-accent: #f5f0e8;
 }
 


### PR DESCRIPTION
## Summary
- Add `--header`, `--header-foreground`, `--header-border` CSS variables to the theme system
- **Default theme**: Header is white (distinct from sidebar)
- **Other 13 themes**: Header inherits sidebar color via `var(--sidebar)`
- Update `BoardPageClient` to use `bg-header` instead of hardcoded colors

## Design Pattern
Uses "exception-based override" pattern:
1. Set default behavior in `:root` (`--header: var(--sidebar)`)
2. Override only for default theme (`--header: #ffffff`)

## Test plan
- [x] Default theme: Header white, Sidebar cream ✅
- [x] Sunrise theme: Header and Sidebar both warm amber ✅
- [x] Lint, TypeCheck, Build passed
- [x] 596 unit tests passed
- [x] 253 E2E tests passed (100%)