### PR TITLE
fix(ui): enable wheel scroll in LinkTypeCombobox and increase URL font size

### DIFF
--- a/components/ui/editable-url-item.tsx
+++ b/components/ui/editable-url-item.tsx
@@ -498,7 +498,7 @@ export const EditableUrlItem = memo(function EditableUrlItem({
                     target="_blank"
                     rel="noopener noreferrer"
                     className={cn(
-                      'min-w-0 flex-1 truncate text-sm text-primary hover:underline',
+                      'min-w-0 flex-1 truncate text-base text-primary hover:underline',
                       'max-w-[300px] sm:max-w-[400px] lg:max-w-none',
                       showSaveSuccess && 'animate-pulse text-success',
                     )}

--- a/components/ui/link-type-combobox.tsx
+++ b/components/ui/link-type-combobox.tsx
@@ -21,7 +21,14 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import * as icons from 'lucide-react'
-import { memo, useState, useMemo, useCallback, createElement } from 'react'
+import {
+  memo,
+  useState,
+  useMemo,
+  useCallback,
+  createElement,
+  useRef,
+} from 'react'
 
 import { Button } from '@/components/ui/button'
 import {
@@ -193,6 +200,21 @@ export const LinkTypeCombobox = memo(function LinkTypeCombobox({
     [onValueChange],
   )
 
+  // Ref for CommandList to enable manual scroll
+  const listRef = useRef<HTMLDivElement>(null)
+
+  /**
+   * Handle wheel events on CommandList
+   *
+   * cmdk library prevents default wheel events for keyboard navigation.
+   * This handler manually scrolls the list to restore mouse/trackpad scrolling.
+   */
+  const handleWheel = useCallback((e: React.WheelEvent<HTMLDivElement>) => {
+    if (listRef.current) {
+      listRef.current.scrollBy(0, e.deltaY)
+    }
+  }, [])
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
@@ -232,7 +254,11 @@ export const LinkTypeCombobox = memo(function LinkTypeCombobox({
             </button>
           )}
 
-          <CommandList className="max-h-[300px]">
+          <CommandList
+            ref={listRef}
+            onWheel={handleWheel}
+            className="max-h-[300px]"
+          >
             <CommandEmpty>No link type found.</CommandEmpty>
 
             {/* User Custom Presets (if any) */}


### PR DESCRIPTION
## Summary
- Enable mouse/trackpad wheel scrolling in LinkTypeCombobox dropdown
- Increase URL link font size from 14px to 16px for better readability

## Changes

### LinkTypeCombobox (components/ui/link-type-combobox.tsx)
- Added `onWheel` handler to `CommandList` that manually calls `scrollBy()`
- Root cause: `cmdk` library prevents default wheel events for keyboard navigation
- Fix bypasses this by programmatically scrolling on wheel events

### EditableUrlItem (components/ui/editable-url-item.tsx)
- Changed URL link font from `text-sm` (14px) to `text-base` (16px)

## Test plan
- [x] TypeScript check passes
- [x] ESLint passes
- [x] Build succeeds
- [x] Unit tests pass
- [x] E2E tests pass (280/281)
- [x] Browser verified: wheel scroll works in LinkTypeCombobox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Increased text size for URL links for improved readability.

* **Bug Fixes**
  * Enhanced mouse wheel scrolling behavior in dropdown selection lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->