### PR TITLE
fix(storybook): resolve KanbanBoard 'Something went wrong' error

### DIFF
--- a/components/Board/KanbanBoard.stories.tsx
+++ b/components/Board/KanbanBoard.stories.tsx
@@ -11,12 +11,76 @@
  * - Columns can be dragged vertically (up/down) and horizontally (left/right)
  * - Uses rectSortingStrategy from @dnd-kit/sortable for full 2D movement
  * - Auto-wrap layout adapts to viewport size
+ *
+ * Note: This component reads data from Redux state (statusLists, repoCards).
+ * In the real app, a Server Component fetches data and hydrates Redux.
+ * For Storybook, we use a decorator to pre-populate Redux with mock data.
  */
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { useLayoutEffect } from 'react'
+import { useDispatch } from 'react-redux'
 import { expect, waitFor } from 'storybook/test'
 
+import type { StatusListDomain, RepoCardForRedux } from '@/lib/models/domain'
+import {
+  setStatusLists,
+  setRepoCards,
+  setBoardError,
+} from '@/lib/redux/slices/boardSlice'
+import { mockStatusLists, mockRepoCards } from '@/mocks/handlers/data'
+
 import { KanbanBoard } from './KanbanBoard'
+
+/**
+ * Transform mock database data to domain models for Redux
+ */
+const transformedStatusLists: StatusListDomain[] = mockStatusLists.map((s) => ({
+  id: s.id,
+  title: s.name,
+  color: s.color,
+  gridRow: s.grid_row,
+  gridCol: s.grid_col,
+  boardId: s.board_id,
+  createdAt: s.created_at,
+  updatedAt: s.updated_at,
+}))
+
+const transformedRepoCards: RepoCardForRedux[] = mockRepoCards.map((c) => ({
+  id: c.id,
+  title: c.repo_name,
+  description: c.meta?.description,
+  statusId: c.status_id,
+  boardId: c.board_id,
+  repoOwner: c.repo_owner,
+  repoName: c.repo_name,
+  order: c.order,
+  meta: c.meta,
+  createdAt: c.created_at,
+  updatedAt: c.updated_at,
+}))
+
+/**
+ * Decorator component that hydrates Redux with mock board data
+ * This simulates what the Server Component does in the real app
+ */
+function ReduxHydrator({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactNode {
+  const dispatch = useDispatch()
+
+  useLayoutEffect(() => {
+    // Clear any persisted error state from localStorage
+    dispatch(setBoardError(null))
+    // Hydrate Redux with mock board data
+    dispatch(setStatusLists(transformedStatusLists))
+    dispatch(setRepoCards(transformedRepoCards))
+  }, [dispatch])
+
+  return children
+}
 
 const meta = {
   title: 'Board/KanbanBoard',
@@ -25,6 +89,13 @@ const meta = {
     layout: 'fullscreen',
   },
   tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ReduxHydrator>
+        <Story />
+      </ReduxHydrator>
+    ),
+  ],
 } satisfies Meta<typeof KanbanBoard>
 
 export default meta

--- a/lib/redux/slices/boardSlice.ts
+++ b/lib/redux/slices/boardSlice.ts
@@ -59,6 +59,18 @@ export const boardSlice = createSlice({
         (card) => card.id !== action.payload,
       )
     },
+    /**
+     * Set loading state
+     */
+    setBoardLoading: (state, action: PayloadAction<boolean>) => {
+      state.loading = action.payload
+    },
+    /**
+     * Set error state (null to clear)
+     */
+    setBoardError: (state, action: PayloadAction<string | null>) => {
+      state.error = action.payload
+    },
   },
 })
 
@@ -68,6 +80,8 @@ export const {
   setRepoCards,
   addRepoCards,
   removeRepoCard,
+  setBoardLoading,
+  setBoardError,
 } = boardSlice.actions
 
 export default boardSlice.reducer


### PR DESCRIPTION
## Summary
- Fix KanbanBoard component showing "Something went wrong" error in Storybook
- Add missing Redux actions (`setBoardLoading`, `setBoardError`) to boardSlice
- Create `ReduxHydrator` decorator to hydrate Redux with mock data in stories

## Root Cause
1. **Missing Redux Hydration**: KanbanBoard reads data from Redux state, but in the real app a Server Component hydrates it. In Storybook, no hydration occurred → empty data
2. **Missing Error Actions**: `boardSlice` had no way to clear persisted error state from localStorage

## Changes
| File | Change |
|------|--------|
| `lib/redux/slices/boardSlice.ts` | Added `setBoardLoading` and `setBoardError` actions |
| `components/Board/KanbanBoard.stories.tsx` | Added `ReduxHydrator` decorator with mock data transformation |

## Test plan
- [x] KanbanBoard Default story renders correctly
- [x] KanbanBoard Docs page renders correctly  
- [x] All story variants display without errors
- [x] Unit tests pass (1316 tests)
- [x] Build succeeds
- [x] Lint passes

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development tooling to ensure consistent mock data rendering in component previews.
  * Improved internal state management capabilities for better error handling and loading state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->