### PR TITLE
fix(add-repo): filter maintenance repos from Add Repository combobox

### DIFF
--- a/src/app/board/[id]/BoardPageClient.stories.tsx
+++ b/src/app/board/[id]/BoardPageClient.stories.tsx
@@ -85,6 +85,7 @@ const createMockInitialData = (): BoardInitialData => ({
   ],
   repoCards: [],
   comments: {},
+  maintenanceRepoIdentifiers: [],
 })
 
 export const Default: Story = {
@@ -171,6 +172,7 @@ export const EmptyBoard: Story = {
       statusLists: [],
       repoCards: [],
       comments: {},
+      maintenanceRepoIdentifiers: [],
     },
   },
 }

--- a/src/app/board/[id]/BoardPageClient.tsx
+++ b/src/app/board/[id]/BoardPageClient.tsx
@@ -274,6 +274,9 @@ export const BoardPageClient = memo(function BoardPageClient({
                 statusId={addRepoCombobox.statusId || statusLists[0]?.id || ''}
                 isOpen={addRepoCombobox.isOpen}
                 onOpenChange={addRepoCombobox.handleOpenChange}
+                maintenanceRepoIdentifiers={
+                  initialData.maintenanceRepoIdentifiers
+                }
                 onRepositoriesAdded={(createdCards: CreatedRepoCard[]) => {
                   // Optimistic UI update: Add cards to Redux state immediately
                   // No page reload needed - cards appear instantly

--- a/src/components/Board/AddRepositoryCombobox.tsx
+++ b/src/components/Board/AddRepositoryCombobox.tsx
@@ -60,6 +60,11 @@ interface AddRepositoryComboboxProps {
    * Called when the combobox should open or close
    */
   onOpenChange?: (open: boolean) => void
+  /**
+   * Lowercase "owner/repo" identifiers of repos in maintenance mode.
+   * These repos will be filtered out from the combobox options.
+   */
+  maintenanceRepoIdentifiers?: string[]
 }
 
 /**
@@ -81,6 +86,7 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
   onQuickNoteFocus,
   isOpen: controlledIsOpen,
   onOpenChange,
+  maintenanceRepoIdentifiers,
 }: AddRepositoryComboboxProps) {
   // State - supports both controlled and uncontrolled modes
   const [internalIsOpen, setInternalIsOpen] = useState(false)
@@ -146,6 +152,16 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
         ),
       ),
     [existingRepoCards],
+  )
+
+  /**
+   * Set of "owner/repo" identifiers for repos in maintenance mode.
+   * Used to filter these repos from the combobox options.
+   * @example Set { "archived/project", "old/repo" }
+   */
+  const maintenanceIdentifiers = useMemo(
+    () => new Set(maintenanceRepoIdentifiers || []),
+    [maintenanceRepoIdentifiers],
   )
 
   // Organization filter state
@@ -305,6 +321,11 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
       (repo) => !existingRepoIdentifiers.has(repo.full_name.toLowerCase()),
     )
 
+    // Filter out repos in maintenance mode
+    filtered = filtered.filter(
+      (repo) => !maintenanceIdentifiers.has(repo.full_name.toLowerCase()),
+    )
+
     // Filter by search query (uses deferred value for non-blocking filtering)
     if (deferredSearchQuery) {
       filtered = filtered.filter(
@@ -339,6 +360,7 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
     organizationFilter,
     visibilityFilter,
     existingRepoIdentifiers,
+    maintenanceIdentifiers,
   ])
 
   const isLoading = isLoadingRepos || isAdding

--- a/src/lib/actions/board-data.ts
+++ b/src/lib/actions/board-data.ts
@@ -19,6 +19,7 @@
 'use server'
 
 import type { StatusListDomain, RepoCardDomain } from '@/lib/models/domain'
+import { createClient } from '@/lib/supabase/server'
 
 import { getBoardData } from './board'
 import { getCommentsForCards, type CommentData } from './project-info'
@@ -36,6 +37,39 @@ export interface BoardInitialData {
   repoCards: RepoCardDomain[]
   /** Map of cardId → comment data (text + color) from projectinfo */
   comments: Record<string, CommentData>
+  /** Lowercase "owner/repo" identifiers of repos in maintenance mode */
+  maintenanceRepoIdentifiers: string[]
+}
+
+/**
+ * Get maintenance repo identifiers for the current user
+ *
+ * Returns lowercase "owner/repo" strings for all repos in maintenance mode.
+ * Used to filter these repos from the Add Repository combobox.
+ *
+ * @returns Array of lowercase "owner/repo" identifiers
+ *
+ * @example
+ * const identifiers = await getUserMaintenanceRepoIdentifiers()
+ * // Returns: ["facebook/react", "vercel/next.js"]
+ */
+export async function getUserMaintenanceRepoIdentifiers(): Promise<string[]> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return []
+
+  const { data } = await supabase
+    .from('maintenance')
+    .select('repo_owner, repo_name')
+    .eq('user_id', user.id)
+
+  return (data || []).map(
+    (item) =>
+      `${item.repo_owner.toLowerCase()}/${item.repo_name.toLowerCase()}`,
+  )
 }
 
 /**
@@ -45,6 +79,7 @@ export interface BoardInitialData {
  * 1. Status lists (columns) - from statuslist table
  * 2. Repo cards - from repocard table
  * 3. Comments - from projectinfo table (batch fetched)
+ * 4. Maintenance repo identifiers - for filtering Add Repository combobox
  *
  * If board has no status lists, creates default ones automatically.
  *
@@ -59,8 +94,13 @@ export interface BoardInitialData {
 export async function fetchBoardInitialData(
   boardId: string,
 ): Promise<BoardInitialData> {
-  // Fetch status lists and repo cards (already parallel in getBoardData)
-  const { statusLists, repoCards } = await getBoardData(boardId)
+  // Fetch board data and maintenance identifiers in parallel
+  const [boardData, maintenanceRepoIdentifiers] = await Promise.all([
+    getBoardData(boardId),
+    getUserMaintenanceRepoIdentifiers(),
+  ])
+
+  const { statusLists, repoCards } = boardData
 
   // Batch fetch comments for all cards
   const comments =
@@ -68,5 +108,5 @@ export async function fetchBoardInitialData(
       ? await getCommentsForCards(repoCards.map((c) => c.id))
       : {}
 
-  return { statusLists, repoCards, comments }
+  return { statusLists, repoCards, comments, maintenanceRepoIdentifiers }
 }

--- a/src/lib/actions/repo-cards.ts
+++ b/src/lib/actions/repo-cards.ts
@@ -106,6 +106,16 @@ export async function addRepositoriesToBoard(
         [],
     )
 
+    // Also exclude repos in maintenance mode (defense-in-depth)
+    const { data: maintenanceRepos } = await supabase
+      .from('maintenance')
+      .select('repo_owner, repo_name')
+      .eq('user_id', user.id)
+
+    for (const m of maintenanceRepos || []) {
+      existingRepoKeys.add(`${m.repo_owner}/${m.repo_name}`)
+    }
+
     // Filter to only non-duplicate repositories
     const newRepos = repositories.filter((repo) => {
       const key = `${repo.owner.login}/${repo.name}`

--- a/src/tests/unit/app/board/BoardPageClient.test.tsx
+++ b/src/tests/unit/app/board/BoardPageClient.test.tsx
@@ -218,6 +218,7 @@ function createMockInitialData(
       },
     ],
     comments: {},
+    maintenanceRepoIdentifiers: [],
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary
- Filter repos in Maintenance Mode from Add Repository combobox
- Client-side: `maintenanceRepoIdentifiers` passed from server → filtered via memoized Set
- Server-side: `addRepositoriesToBoard` checks maintenance table (defense-in-depth)
- Uses `Promise.all` for parallel fetching (no added latency)

## Test plan
- [x] TypeScript: No errors
- [x] ESLint: No warnings
- [x] Unit Tests: 1265 passed
- [x] Build: Successful
- [x] E2E Tests: 293 passed

## Manual verification
1. Move repo X to Maintenance Mode
2. Open Add Repository combobox
3. Search for repo X → Should NOT appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repositories marked as in maintenance are now automatically excluded from the add repository dropdown, streamlining board management.

* **Improvements**
  * Added backend validation to prevent maintenance-mode repositories from being added to boards, ensuring data consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->