### PR TITLE
fix(kanban): prevent columns from expanding to fill available space

### DIFF
--- a/e2e/logged-in/kanban-column-width.spec.ts
+++ b/e2e/logged-in/kanban-column-width.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Kanban Column Width E2E Tests
+ *
+ * Tests for column width constraints to prevent columns from expanding
+ * to fill available space when fewer columns exist on the board.
+ *
+ * Bug fix: Columns expanded horizontally when fewer columns existed.
+ * Fix: Changed from minmax(280px, 1fr) to minmax(280px, var(--column-width))
+ * where --column-width is defined as 320px CSS variable.
+ */
+
+import { test, expect } from '../fixtures/coverage'
+
+test.describe('Kanban Column Width Constraints', () => {
+  test.use({ storageState: 'e2e/.auth/user.json' })
+
+  const BOARD_URL = '/board/board-1'
+
+  test('CSS variable --column-width should be defined as 320px', async ({
+    page,
+  }) => {
+    await page.goto(BOARD_URL)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for hydration
+    await page.waitForTimeout(500)
+
+    const columnWidth = await page.evaluate(() => {
+      return getComputedStyle(document.documentElement)
+        .getPropertyValue('--column-width')
+        .trim()
+    })
+
+    expect(columnWidth).toBe('320px')
+  })
+
+  test('grid should use CSS variable for column sizing', async ({ page }) => {
+    await page.goto(BOARD_URL)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for hydration - grid appears after isMounted is true
+    await page.waitForTimeout(500)
+
+    const gridStyle = await page.evaluate(() => {
+      const grid = document.querySelector('.grid.gap-4.pb-4')
+      if (!grid) return null
+      return grid.getAttribute('style')
+    })
+
+    expect(gridStyle).not.toBeNull()
+    expect(gridStyle).toContain('var(--column-width)')
+  })
+
+  test('columns should not expand beyond max-width when few columns exist', async ({
+    page,
+  }) => {
+    await page.goto(BOARD_URL)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for hydration
+    await page.waitForTimeout(500)
+
+    // Get all sortable columns (the wrapper divs that contain status columns)
+    const columns = page.locator('[data-testid^="sortable-column-"]')
+    const columnCount = await columns.count()
+
+    expect(columnCount).toBeGreaterThan(0)
+
+    // Each column should have computed width <= 320px (plus some tolerance for borders/padding)
+    // The column width is constrained by CSS Grid minmax(280px, var(--column-width))
+    for (let i = 0; i < Math.min(columnCount, 3); i++) {
+      const column = columns.nth(i)
+      const box = await column.boundingBox()
+
+      // Column should exist and have reasonable width
+      expect(box).not.toBeNull()
+      // Max width should be around 320px (allowing for small variations)
+      expect(box!.width).toBeLessThanOrEqual(360) // 320px + tolerance
+      expect(box!.width).toBeGreaterThanOrEqual(280) // Min width
+    }
+  })
+
+  test('column width should remain consistent regardless of column count', async ({
+    page,
+  }) => {
+    await page.goto(BOARD_URL)
+    await page.waitForLoadState('networkidle')
+
+    // Wait for hydration
+    await page.waitForTimeout(500)
+
+    // Get column widths
+    const columns = page.locator('[data-testid^="sortable-column-"]')
+    const columnCount = await columns.count()
+
+    if (columnCount > 1) {
+      const firstColumnBox = await columns.first().boundingBox()
+      const lastColumnBox = await columns.last().boundingBox()
+
+      // All columns should have similar widths (constrained by CSS variable)
+      expect(firstColumnBox).not.toBeNull()
+      expect(lastColumnBox).not.toBeNull()
+
+      // Width difference should be minimal (within 10px)
+      const widthDiff = Math.abs(firstColumnBox!.width - lastColumnBox!.width)
+      expect(widthDiff).toBeLessThanOrEqual(10)
+    }
+  })
+})

--- a/e2e/logged-in/kanban-scroll.spec.ts
+++ b/e2e/logged-in/kanban-scroll.spec.ts
@@ -105,7 +105,7 @@ test.describe('Kanban Board Horizontal Scroll', () => {
     // Verify grid has inline style with gridTemplateColumns
     expect(gridStyle).not.toBeNull()
     expect(gridStyle).toContain('grid-template-columns')
-    expect(gridStyle).toContain('minmax(280px, 1fr)')
+    expect(gridStyle).toContain('minmax(280px, var(--column-width))')
   })
 
   test('should allow adding new columns via Add Column button', async ({

--- a/src/components/Board/KanbanBoard.tsx
+++ b/src/components/Board/KanbanBoard.tsx
@@ -776,13 +776,14 @@ export const KanbanBoard = memo<KanbanBoardProps>(
                 isMounted
                   ? {
                       // Add extra column when dragging to allow insertion at end
-                      gridTemplateColumns: `repeat(${gridDimensions.maxCol + 1 + (activeDragType === 'column' ? 1 : 0)}, minmax(280px, 1fr))`,
+                      gridTemplateColumns: `repeat(${gridDimensions.maxCol + 1 + (activeDragType === 'column' ? 1 : 0)}, minmax(280px, var(--column-width)))`,
                       // Use minmax(min-content, auto) for auto-height expansion (columns grow to fit cards)
                       gridTemplateRows: `repeat(${gridDimensions.maxRow + 1 + (activeDragType === 'column' ? 1 : 0)}, minmax(min-content, auto))`,
                     }
                   : {
                       // Stable initial styles for SSR hydration
-                      gridTemplateColumns: 'repeat(1, minmax(280px, 1fr))',
+                      gridTemplateColumns:
+                        'repeat(1, minmax(280px, var(--column-width)))',
                       gridTemplateRows: 'repeat(1, auto)',
                     }
               }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -21,6 +21,7 @@
 /*---break---
  */
 @theme inline {
+  --column-width: 320px;
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
@@ -68,6 +69,7 @@
 /*---break---
  */
 :root {
+  --column-width: 320px;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -112,6 +114,7 @@
 /*---break---
  */
 .dark {
+  --column-width: 320px;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);

--- a/src/tests/unit/components/Board/KanbanBoard.test.tsx
+++ b/src/tests/unit/components/Board/KanbanBoard.test.tsx
@@ -110,7 +110,7 @@ describe('KanbanBoard Horizontal Scroll Tests', () => {
 
         if (gridContainer) {
           const style = gridContainer.getAttribute('style')
-          // Should have gridTemplateColumns with minmax(280px, 1fr)
+          // Should have gridTemplateColumns with minmax(280px, var(--column-width))
           expect(style).toContain('grid-template-columns')
         }
       })
@@ -247,22 +247,26 @@ describe('Horizontal Scroll Technical Requirements', () => {
   })
 
   describe('Grid Column Sizing', () => {
-    it('should use minmax(280px, 1fr) for flexible column sizing', () => {
-      // minmax(280px, 1fr) ensures:
+    it('should use minmax(280px, var(--column-width)) for constrained column sizing', () => {
+      // minmax(280px, var(--column-width)) ensures:
       // - Minimum width of 280px per column
-      // - Maximum width grows equally (1fr) when space available
-      const gridTemplatePattern = 'minmax(280px, 1fr)'
+      // - Maximum width constrained by CSS variable (320px) to prevent expansion
+      const gridTemplatePattern = 'minmax(280px, var(--column-width))'
       expect(gridTemplatePattern).toContain('280px')
-      expect(gridTemplatePattern).toContain('1fr')
+      expect(gridTemplatePattern).toContain('var(--column-width)')
     })
 
     it('should calculate grid template for N columns', () => {
       const generateGridTemplate = (cols: number): string => {
-        return `repeat(${cols}, minmax(280px, 1fr))`
+        return `repeat(${cols}, minmax(280px, var(--column-width)))`
       }
 
-      expect(generateGridTemplate(6)).toBe('repeat(6, minmax(280px, 1fr))')
-      expect(generateGridTemplate(10)).toBe('repeat(10, minmax(280px, 1fr))')
+      expect(generateGridTemplate(6)).toBe(
+        'repeat(6, minmax(280px, var(--column-width)))',
+      )
+      expect(generateGridTemplate(10)).toBe(
+        'repeat(10, minmax(280px, var(--column-width)))',
+      )
     })
   })
 
@@ -1468,7 +1472,7 @@ describe('KanbanBoard Multi-Row Layout', () => {
     // Verify 2 columns template
     const gridContainer = container.querySelector('.grid.gap-4.pb-4')
     const style = gridContainer?.getAttribute('style')
-    expect(style).toContain('repeat(2, minmax(280px, 1fr))')
+    expect(style).toContain('repeat(2, minmax(280px, var(--column-width))')
     expect(style).toContain('repeat(2, minmax(min-content, auto))')
   })
 })


### PR DESCRIPTION
## Summary

- Columns were expanding horizontally when fewer columns existed on the board
- Root cause: CSS Grid's `minmax(280px, 1fr)` where `1fr` distributes remaining space equally
- Fix: Use CSS variable `--column-width: 320px` to constrain maximum column width

## Changes

| File | Change |
|------|--------|
| `src/styles/globals.css` | Add `--column-width: 320px` CSS variable |
| `src/components/Board/KanbanBoard.tsx` | Change `minmax(280px, 1fr)` → `minmax(280px, var(--column-width))` |
| `e2e/logged-in/kanban-column-width.spec.ts` | New E2E tests for column width constraints |
| `e2e/logged-in/kanban-scroll.spec.ts` | Update assertion to use CSS variable |
| `src/tests/unit/components/Board/KanbanBoard.test.tsx` | Update unit tests |

## Before/After

**Before (1 column):** Column expands to fill entire viewport width
**After (1 column):** Column stays at max 320px width

## Test plan

- [x] `pnpm test` - Unit tests pass
- [x] `pnpm e2e` - E2E tests pass (288 passed)
- [x] `pnpm lint` - No errors
- [x] `pnpm typecheck` - No errors
- [x] `pnpm build` - Successful
- [x] Manual verification via Claude Chrome

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kanban board columns now use a consistent, fixed width for improved layout stability and uniformity across different screen configurations.

* **Tests**
  * Added end-to-end test suite to validate column width constraints and consistency across varying column counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->