### PR TITLE
fix: prevent open redirect in OAuth callback

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -41,8 +41,13 @@ export async function GET(request: Request) {
    */
   const rawNext = searchParams.get('next') ?? '/boards'
   // Prevent open redirect: only allow relative paths, block protocol-relative URLs
+  // Also block backslash variants (/\evil.com) — WHATWG URL Standard normalizes \ to / for http/https
   const next =
-    rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/boards'
+    rawNext.startsWith('/') &&
+    !rawNext.startsWith('//') &&
+    !rawNext.includes('\\')
+      ? rawNext
+      : '/boards'
 
   if (code) {
     const supabase = await createRouteHandlerClient(request)


### PR DESCRIPTION
## Summary

Fixes #58 — Validates the `next` query parameter in the OAuth callback to prevent open redirect attacks.

## Changes

**File:** `src/app/auth/callback/route.ts`

The `next` query parameter was used directly in `NextResponse.redirect()` without validation. An attacker could craft a malicious URL like `?next=//evil.com` to redirect authenticated users to a phishing site after login.

**Before:**
```typescript
const next = searchParams.get('next') ?? '/boards'
```

**After:**
```typescript
const rawNext = searchParams.get('next') ?? '/boards'
const next = rawNext.startsWith('/') && !rawNext.startsWith('//') ? rawNext : '/boards'
```

## Security Impact

- **OWASP:** A07 — Identification and Authentication Failures
- **Attack vector:** `//evil.com` (protocol-relative URL) or absolute URLs
- **Fix:** Only allow relative paths starting with `/` (not `//`), fallback to `/boards`

## Test plan

- [ ] Verify normal login flow still redirects to `/boards`
- [ ] Verify `?next=/board/123` correctly redirects to `/board/123`
- [ ] Verify `?next=//evil.com` falls back to `/boards`
- [ ] Verify `?next=https://evil.com` falls back to `/boards`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of post-login redirect paths: unsafe or malformed redirects are now rejected and users are routed to the main boards page, preventing navigation to unintended locations after authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->