### PR TITLE
fix: drop stale create_default_board trigger

### DIFF
--- a/src/supabase/migrations/20260212100000_drop_create_default_board_trigger.sql
+++ b/src/supabase/migrations/20260212100000_drop_create_default_board_trigger.sql
@@ -1,0 +1,24 @@
+-- GitBox - Drop Stale create_default_board Trigger
+-- Created: 2026-02-12
+-- Purpose: Remove the auth.users INSERT trigger that auto-creates a board.
+--
+-- The app-level createFirstBoardIfNeeded() in the OAuth callback is the
+-- preferred mechanism: it creates both the board AND its 5 default status
+-- lists atomically. The trigger only created a bare board without columns.
+--
+-- History:
+--   20251115 initial_schema.sql — created trigger + function
+--   20260204 drop_board_theme.sql — updated function to remove theme param
+--   This migration — drops both trigger and function
+
+-- ============================================================================
+-- Step 1: Drop the trigger on auth.users
+-- ============================================================================
+
+DROP TRIGGER IF EXISTS on_user_created ON auth.users;
+
+-- ============================================================================
+-- Step 2: Drop the function (no longer referenced)
+-- ============================================================================
+
+DROP FUNCTION IF EXISTS create_default_board();


### PR DESCRIPTION
## Summary
- Drop the `on_user_created` trigger on `auth.users` and its `create_default_board()` function
- The trigger created bare boards without status lists, duplicating the app-level `createFirstBoardIfNeeded()` which creates boards with 5 default columns atomically
- Single board creation path eliminates potential race conditions and orphan boards

Closes #82

## Test plan
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes
- [ ] `supabase db reset` applies migration cleanly (local verification)
- [ ] New user registration still creates first board via OAuth callback