### PR TITLE
fix: use Supabase .upsert() for projectinfo operations

### DIFF
--- a/src/lib/actions/shared-project-info.ts
+++ b/src/lib/actions/shared-project-info.ts
@@ -290,56 +290,22 @@ export async function upsertProjectInfoCore(
     .filter((link) => link.url && link.url.trim() !== '')
     .map((link) => ({ type: link.type, url: link.url }))
 
-  try {
-    const { data: existingInfo } = await supabase
-      .from('projectinfo')
-      .select('id')
-      .eq(fk.column, entityId)
-      .single<{ id: string }>()
+  const upsertData = {
+    [fk.column]: entityId,
+    note: data.note,
+    comment: data.comment,
+    links: linksArray,
+  } as ProjectInfoInsert
 
-    if (existingInfo) {
-      const updateData: ProjectInfoUpdate = {
-        note: data.note,
-        comment: data.comment,
-        links: linksArray,
-        updated_at: new Date().toISOString(),
-      }
+  const { error } = await supabase
+    .from('projectinfo')
+    .upsert(upsertData, { onConflict: fk.column })
 
-      const { error: updateError } = await supabase
-        .from('projectinfo')
-        .update(updateData)
-        .eq('id', existingInfo.id)
-
-      if (updateError) {
-        Sentry.captureException(updateError, {
-          extra: { context: `Update ${fk.label}`, entityId },
-        })
-        throw new Error('Failed to update project information')
-      }
-    } else {
-      const insertData: ProjectInfoInsert = {
-        [fk.column]: entityId,
-        note: data.note,
-        comment: data.comment,
-        links: linksArray,
-      }
-
-      const { error: createError } = await supabase
-        .from('projectinfo')
-        .insert(insertData)
-
-      if (createError) {
-        Sentry.captureException(createError, {
-          extra: { context: `Create ${fk.label}`, entityId },
-        })
-        throw new Error('Failed to create project information')
-      }
-    }
-  } catch (error) {
-    if (error instanceof Error) {
-      throw error
-    }
-    throw new Error('An error occurred while saving project information')
+  if (error) {
+    Sentry.captureException(error, {
+      extra: { context: `Upsert ${fk.label}`, entityId },
+    })
+    throw new Error('Failed to save project information')
   }
 }
 

--- a/src/supabase/migrations/20260212110000_add_unique_maintenance_id_to_projectinfo.sql
+++ b/src/supabase/migrations/20260212110000_add_unique_maintenance_id_to_projectinfo.sql
@@ -1,0 +1,13 @@
+-- GitBox - Add UNIQUE constraint on projectinfo.maintenance_id
+-- Created: 2026-02-12
+-- Purpose: Enable Supabase .upsert({ onConflict: 'maintenance_id' })
+--
+-- repo_card_id already has UNIQUE from the initial schema.
+-- maintenance_id only had a regular INDEX. Adding UNIQUE allows both FK
+-- columns to be used as upsert conflict targets.
+--
+-- PostgreSQL allows multiple NULLs in UNIQUE columns by default, so rows
+-- where maintenance_id IS NULL are unaffected.
+
+ALTER TABLE projectinfo
+ADD CONSTRAINT projectinfo_maintenance_id_key UNIQUE (maintenance_id);


### PR DESCRIPTION
## Summary
- Replace select-then-insert/update anti-pattern in `upsertProjectInfoCore` with a single `.upsert()` call
- Reduces two DB round-trips to one, simplifies ~50 lines to ~15 lines
- Add UNIQUE constraint on `projectinfo.maintenance_id` (required for `onConflict`; `repo_card_id` already had UNIQUE)
- `updateCommentCore`/`updateCommentColorCore` unchanged — they update partial fields, and `.upsert()` would overwrite unrelated columns

Closes #67

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] `pnpm build` passes
- [ ] `supabase db reset` applies migration cleanly
- [ ] E2E: save project info on board card → data persists
- [ ] E2E: save project info on maintenance item → data persists