### PR TITLE
fix: add CSP + Permissions-Policy security headers (#59)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -47,12 +47,30 @@ const nextConfig: NextConfig = {
             value: 'nosniff',
           },
           {
-            key: 'X-XSS-Protection',
-            value: '1; mode=block',
-          },
-          {
             key: 'Referrer-Policy',
             value: 'strict-origin-when-cross-origin',
+          },
+          {
+            // Report-Only mode: logs violations without blocking resources.
+            // Switch to Content-Security-Policy (enforcement) once stable.
+            key: 'Content-Security-Policy-Report-Only',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' https://avatars.githubusercontent.com https://github.com data: blob:",
+              "connect-src 'self' https://*.supabase.co http://127.0.0.1:* https://api.github.com https://*.ingest.us.sentry.io https://vitals.vercel-insights.com",
+              "font-src 'self'",
+              "frame-ancestors 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+              "object-src 'none'",
+            ].join('; '),
+          },
+          {
+            key: 'Permissions-Policy',
+            value:
+              'camera=(), microphone=(), geolocation=(), payment=(), usb=(), bluetooth=()',
           },
         ],
       },


### PR DESCRIPTION
## Summary
- Added `Content-Security-Policy-Report-Only` header with restrictive directives for scripts, styles, images, connections, fonts, frames, and objects
- Added `Permissions-Policy` header disabling camera, microphone, geolocation, payment, USB, and bluetooth APIs
- Removed deprecated `X-XSS-Protection` header (superseded by CSP)

**Note:** CSP starts in **Report-Only** mode — violations are logged to browser console without blocking resources. Switch to enforcement (`Content-Security-Policy`) once no legitimate violations are observed.

## CSP Directives
| Directive | Value |
|-----------|-------|
| default-src | `'self'` |
| script-src | `'self' 'unsafe-inline' 'unsafe-eval'` + Vercel scripts |
| style-src | `'self' 'unsafe-inline'` |
| img-src | `'self'` + GitHub avatars + `data:` + `blob:` |
| connect-src | `'self'` + Supabase + GitHub API + Sentry + Vercel Insights |
| font-src | `'self'` |
| frame-ancestors | `'none'` |
| object-src | `'none'` |

## Test plan
- [ ] Verify CSP-Report-Only header is present in response headers
- [ ] Check browser console for CSP violation reports
- [ ] Verify Permissions-Policy header is present
- [ ] Verify X-XSS-Protection header is removed
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm build` passes

Closes #59