### PR TITLE
refactor: standardize Server Action error handling with ActionResult<T> (#68)

### DIFF
--- a/src/components/Board/AddRepositoryCombobox.tsx
+++ b/src/components/Board/AddRepositoryCombobox.tsx
@@ -222,13 +222,13 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
         fetchAll: true, // Enable pagination to fetch all repos
       })
 
-      if (result.error) {
+      if (!result.success) {
         setReposError(result.error)
         setUserRepos([])
         return
       }
 
-      const allRepos = result.data || []
+      const allRepos = [...result.data]
 
       // Additionally fetch organization repos to ensure org repos are visible
       // The /user/repos API may not return all org repos, so we need to supplement
@@ -242,7 +242,7 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
         // Merge org repos with user repos, deduplicating by repo id
         const existingIds = new Set(allRepos.map((repo) => repo.id))
         for (const orgResult of orgResults) {
-          if (orgResult.data) {
+          if (orgResult.success) {
             for (const repo of orgResult.data) {
               if (!existingIds.has(repo.id)) {
                 allRepos.push(repo)
@@ -279,11 +279,11 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
         getAuthenticatedUserOrganizations(),
       ])
 
-      if (userResult.data) {
+      if (userResult.success) {
         setCurrentUser(userResult.data)
       }
 
-      if (orgsResult.data) {
+      if (orgsResult.success) {
         setOrganizations(orgsResult.data)
       }
     } catch (error) {

--- a/src/components/Modals/CreateLinkTypeDialog.tsx
+++ b/src/components/Modals/CreateLinkTypeDialog.tsx
@@ -115,16 +115,12 @@ export const CreateLinkTypeDialog = memo(function CreateLinkTypeDialog({
     }
 
     startTransition(async () => {
-      try {
-        const preset = await createUserPreset(trimmedLabel, icon)
-        onCreated?.(preset)
+      const result = await createUserPreset(trimmedLabel, icon)
+      if (result.success) {
+        onCreated?.(result.data)
         handleClose()
-      } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message)
-        } else {
-          setError('Failed to create custom type')
-        }
+      } else {
+        setError(result.error)
       }
     })
   }

--- a/src/components/Modals/NoteModal.tsx
+++ b/src/components/Modals/NoteModal.tsx
@@ -109,9 +109,9 @@ export const NoteModal = memo(function NoteModal({
   useEffect(() => {
     let mounted = true
     getUserPresets()
-      .then((presets) => {
-        if (mounted) {
-          setUserPresets(presets)
+      .then((result) => {
+        if (mounted && result.success) {
+          setUserPresets(result.data)
         }
       })
       .catch(() => {

--- a/src/lib/actions/auth-guard.ts
+++ b/src/lib/actions/auth-guard.ts
@@ -20,10 +20,13 @@
 
 'use server'
 
+import * as Sentry from '@sentry/nextjs'
 import type { SupabaseClient, User } from '@supabase/supabase-js'
 
 import { createClient } from '@/lib/supabase/server'
 import type { Database } from '@/lib/supabase/types'
+
+import type { ActionResult } from './types'
 
 /**
  * Wraps a Server Action with authentication, providing an authenticated
@@ -57,4 +60,54 @@ export async function withAuth<T>(
   }
 
   return action(supabase, user)
+}
+
+/**
+ * Wraps a Server Action with authentication, returning ActionResult<T>
+ * instead of throwing on failure.
+ *
+ * Use this for client-consumed Server Actions where the caller expects
+ * a result object rather than handling exceptions.
+ *
+ * @param action - Async function receiving authenticated supabase client and user
+ * @returns ActionResult<T> with success/data or error
+ *
+ * @example
+ * export const createPreset = (label: string) =>
+ *   withAuthResult(async (supabase, user) => {
+ *     const { data, error } = await supabase
+ *       .from('presets')
+ *       .insert({ label, user_id: user.id })
+ *       .select()
+ *       .single()
+ *     if (error) throw error
+ *     return data
+ *   })
+ */
+export async function withAuthResult<T>(
+  action: (supabase: SupabaseClient<Database>, user: User) => Promise<T>,
+): Promise<ActionResult<T>> {
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    return { success: false, error: 'Authentication required' }
+  }
+
+  try {
+    const data = await action(supabase, user)
+    return { success: true, data }
+  } catch (error) {
+    Sentry.captureException(error, {
+      extra: { context: 'withAuthResult' },
+    })
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : 'An unexpected error occurred',
+    }
+  }
 }

--- a/src/lib/actions/github.ts
+++ b/src/lib/actions/github.ts
@@ -15,6 +15,8 @@ import { isAxiosError } from 'axios'
 import { createGitHubAxios, hasGitHubToken } from '@/lib/axios-github'
 import { createModuleLogger } from '@/lib/logger'
 
+import type { ActionResult } from './types'
+
 const log = createModuleLogger('github')
 
 export interface GitHubRepository {
@@ -117,10 +119,10 @@ export async function getAuthenticatedUserRepositories(params?: {
   per_page?: number
   page?: number
   fetchAll?: boolean
-}): Promise<{ data: GitHubRepository[] | null; error: string | null }> {
+}): Promise<ActionResult<GitHubRepository[]>> {
   if (!(await hasGitHubToken())) {
     return {
-      data: null,
+      success: false,
       error: 'GitHub token not found. Please sign in again.',
     }
   }
@@ -157,7 +159,7 @@ export async function getAuthenticatedUserRepositories(params?: {
         page++
       }
 
-      return { data: allRepos, error: null }
+      return { success: true, data: allRepos }
     }
 
     // Single page fetch (original behavior)
@@ -170,10 +172,10 @@ export async function getAuthenticatedUserRepositories(params?: {
       `/user/repos?${searchParams.toString()}`,
     )
 
-    return { data, error: null }
+    return { success: true, data }
   } catch (error) {
     return {
-      data: null,
+      success: false,
       error: handleGitHubError(error, 'fetch repositories'),
     }
   }
@@ -190,13 +192,12 @@ export async function getAuthenticatedUserRepositories(params?: {
  * const { data, error } = await getAuthenticatedUser()
  * if (data) console.log(data.login) // => "ryota-murakami"
  */
-export async function getAuthenticatedUser(): Promise<{
-  data: GitHubUser | null
-  error: string | null
-}> {
+export async function getAuthenticatedUser(): Promise<
+  ActionResult<GitHubUser>
+> {
   if (!(await hasGitHubToken())) {
     return {
-      data: null,
+      success: false,
       error: 'GitHub token not found. Please sign in again.',
     }
   }
@@ -205,10 +206,10 @@ export async function getAuthenticatedUser(): Promise<{
 
   try {
     const { data } = await api.get<GitHubUser>('/user')
-    return { data, error: null }
+    return { success: true, data }
   } catch (error) {
     return {
-      data: null,
+      success: false,
       error: handleGitHubError(error, 'fetch user'),
     }
   }
@@ -234,10 +235,10 @@ export async function getOrganizationRepositories(
     per_page?: number
     fetchAll?: boolean
   },
-): Promise<{ data: GitHubRepository[] | null; error: string | null }> {
+): Promise<ActionResult<GitHubRepository[]>> {
   if (!(await hasGitHubToken())) {
     return {
-      data: null,
+      success: false,
       error: 'GitHub token not found. Please sign in again.',
     }
   }
@@ -273,7 +274,7 @@ export async function getOrganizationRepositories(
         page++
       }
 
-      return { data: allRepos, error: null }
+      return { success: true, data: allRepos }
     }
 
     // Single page fetch
@@ -285,13 +286,13 @@ export async function getOrganizationRepositories(
       `/orgs/${org}/repos?${searchParams.toString()}`,
     )
 
-    return { data, error: null }
+    return { success: true, data }
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 404) {
-      return { data: null, error: `Organization '${org}' not found.` }
+      return { success: false, error: `Organization '${org}' not found.` }
     }
     return {
-      data: null,
+      success: false,
       error: handleGitHubError(error, 'fetch organization repositories'),
     }
   }
@@ -309,13 +310,12 @@ export async function getOrganizationRepositories(
  * const { data, error } = await getAuthenticatedUserOrganizations()
  * if (data) data.forEach(org => console.log(org.login))
  */
-export async function getAuthenticatedUserOrganizations(): Promise<{
-  data: GitHubOrganization[] | null
-  error: string | null
-}> {
+export async function getAuthenticatedUserOrganizations(): Promise<
+  ActionResult<GitHubOrganization[]>
+> {
   if (!(await hasGitHubToken())) {
     return {
-      data: null,
+      success: false,
       error: 'GitHub token not found. Please sign in again.',
     }
   }
@@ -324,10 +324,10 @@ export async function getAuthenticatedUserOrganizations(): Promise<{
 
   try {
     const { data } = await api.get<GitHubOrganization[]>('/user/orgs')
-    return { data, error: null }
+    return { success: true, data }
   } catch (error) {
     return {
-      data: null,
+      success: false,
       error: handleGitHubError(error, 'fetch organizations'),
     }
   }

--- a/src/lib/actions/types.ts
+++ b/src/lib/actions/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Standardized Server Action Result Types
+ *
+ * Provides a discriminated union type for Server Action return values,
+ * replacing the mix of throw-based and ad-hoc result patterns.
+ *
+ * Pattern:
+ * - Client-consumed Server Actions → return ActionResult<T>
+ * - Internal helpers / server-component-only functions → may still throw
+ *
+ * @see https://github.com/laststance/gitbox/issues/68
+ *
+ * @example
+ * // Server Action
+ * export async function createItem(name: string): Promise<ActionResult<Item>> {
+ *   try {
+ *     const item = await db.items.create({ name })
+ *     return { success: true, data: item }
+ *   } catch (error) {
+ *     return { success: false, error: 'Failed to create item' }
+ *   }
+ * }
+ *
+ * // Client caller
+ * const result = await createItem('foo')
+ * if (result.success) {
+ *   console.log(result.data) // Item (narrowed)
+ * } else {
+ *   toast.error(result.error) // string (narrowed)
+ * }
+ */
+
+/**
+ * Discriminated union for Server Action results.
+ *
+ * @param T - The data type on success
+ * @returns Either `{ success: true, data: T }` or `{ success: false, error: string }`
+ *
+ * @example
+ * type Result = ActionResult<User[]>
+ * // => { success: true; data: User[] } | { success: false; error: string }
+ */
+export type ActionResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string }

--- a/src/lib/actions/user-presets.ts
+++ b/src/lib/actions/user-presets.ts
@@ -18,6 +18,8 @@ import {
   MAX_CUSTOM_PRESETS,
 } from '@/lib/validations/user-presets'
 
+import type { ActionResult } from './types'
+
 type UserLinkPresetInsert = TablesInsert<'user_link_presets'>
 
 /**
@@ -31,42 +33,6 @@ export interface UserPreset {
 }
 
 /**
- * Validate preset value format using Zod schema.
- *
- * @param value - The value to validate
- * @throws Error if value is invalid
- *
- * @example
- * validateValue('my-custom-preset') // => void (success)
- * validateValue('My Preset')        // => throws Error (not kebab-case)
- * validateValue('vercel')           // => throws Error (built-in)
- */
-function validateValue(value: string): void {
-  const result = presetValueSchema.safeParse(value)
-  if (!result.success) {
-    throw new Error(result.error.issues[0]?.message || 'Invalid value')
-  }
-}
-
-/**
- * Validate preset label using Zod schema.
- *
- * @param label - The label to validate
- * @throws Error if label is invalid
- *
- * @example
- * validateLabel('My Custom Service') // => void (success)
- * validateLabel('')                   // => throws Error (required)
- * validateLabel('x'.repeat(51))       // => throws Error (too long)
- */
-function validateLabel(label: string): void {
-  const result = presetLabelSchema.safeParse(label)
-  if (!result.success) {
-    throw new Error(result.error.issues[0]?.message || 'Invalid label')
-  }
-}
-
-/**
  * Get all custom presets for the current user
  *
  * @returns Array of user presets sorted by label
@@ -75,7 +41,7 @@ function validateLabel(label: string): void {
  * const presets = await getUserPresets()
  * // Returns: [{ id: '...', value: 'my-service', label: 'My Service', icon: 'Link' }, ...]
  */
-export async function getUserPresets(): Promise<UserPreset[]> {
+export async function getUserPresets(): Promise<ActionResult<UserPreset[]>> {
   const supabase = await createClient()
 
   const {
@@ -83,7 +49,7 @@ export async function getUserPresets(): Promise<UserPreset[]> {
   } = await supabase.auth.getUser()
 
   if (!user) {
-    return []
+    return { success: true, data: [] }
   }
 
   const { data, error } = await supabase
@@ -96,15 +62,18 @@ export async function getUserPresets(): Promise<UserPreset[]> {
     Sentry.captureException(error, {
       extra: { context: 'Get user presets', userId: user.id },
     })
-    throw new Error('Failed to fetch custom presets')
+    return { success: false, error: 'Failed to fetch custom presets' }
   }
 
-  return (data || []).map((row) => ({
-    id: row.id,
-    value: row.value,
-    label: row.label,
-    icon: row.icon || 'Link',
-  }))
+  return {
+    success: true,
+    data: (data || []).map((row) => ({
+      id: row.id,
+      value: row.value,
+      label: row.label,
+      icon: row.icon || 'Link',
+    })),
+  }
 }
 
 /**
@@ -122,7 +91,7 @@ export async function getUserPresets(): Promise<UserPreset[]> {
 export async function createUserPreset(
   label: string,
   icon?: string,
-): Promise<UserPreset> {
+): Promise<ActionResult<UserPreset>> {
   const supabase = await createClient()
 
   const {
@@ -130,13 +99,25 @@ export async function createUserPreset(
   } = await supabase.auth.getUser()
 
   if (!user) {
-    throw new Error('Authentication required')
+    return { success: false, error: 'Authentication required' }
   }
 
   // Validate inputs
-  validateLabel(label)
+  const labelResult = presetLabelSchema.safeParse(label)
+  if (!labelResult.success) {
+    return {
+      success: false,
+      error: labelResult.error.issues[0]?.message || 'Invalid label',
+    }
+  }
   const value = labelToValue(label)
-  validateValue(value)
+  const valueResult = presetValueSchema.safeParse(value)
+  if (!valueResult.success) {
+    return {
+      success: false,
+      error: valueResult.error.issues[0]?.message || 'Invalid value',
+    }
+  }
 
   // Check preset limit
   const { count, error: countError } = await supabase
@@ -148,13 +129,14 @@ export async function createUserPreset(
     Sentry.captureException(countError, {
       extra: { context: 'Count user presets', userId: user.id },
     })
-    throw new Error('Failed to check preset limit')
+    return { success: false, error: 'Failed to check preset limit' }
   }
 
   if ((count || 0) >= MAX_CUSTOM_PRESETS) {
-    throw new Error(
-      `Maximum of ${MAX_CUSTOM_PRESETS} custom presets reached. Delete some to add more.`,
-    )
+    return {
+      success: false,
+      error: `Maximum of ${MAX_CUSTOM_PRESETS} custom presets reached. Delete some to add more.`,
+    }
   }
 
   // Check for duplicate value
@@ -166,7 +148,7 @@ export async function createUserPreset(
     .single()
 
   if (existing) {
-    throw new Error('A preset with this name already exists')
+    return { success: false, error: 'A preset with this name already exists' }
   }
 
   // Create preset
@@ -187,13 +169,16 @@ export async function createUserPreset(
     Sentry.captureException(error, {
       extra: { context: 'Create user preset', userId: user.id, label },
     })
-    throw new Error('Failed to create custom preset')
+    return { success: false, error: 'Failed to create custom preset' }
   }
 
   return {
-    id: data.id,
-    value: data.value,
-    label: data.label,
-    icon: data.icon || 'Link',
+    success: true,
+    data: {
+      id: data.id,
+      value: data.value,
+      label: data.label,
+      icon: data.icon || 'Link',
+    },
   }
 }


### PR DESCRIPTION
## Summary
- Created `ActionResult<T>` discriminated union type in `src/lib/actions/types.ts` for type-safe error handling
- Added `withAuthResult<T>()` helper in `auth-guard.ts` — wraps auth + try/catch + Sentry in one call
- Converted `github.ts` from `{data: T | null, error: string | null}` to `ActionResult<T>` (4 functions)
- Converted `user-presets.ts` from throw-based to `ActionResult<T>` (2 functions)
- Updated 3 callers to use discriminated union pattern (`result.success` checks)

## Pattern
```typescript
// Server Action returns ActionResult<T>
export async function getItems(): Promise<ActionResult<Item[]>> {
  // ... return { success: true, data } or { success: false, error }
}

// Caller uses discriminated union narrowing
const result = await getItems()
if (result.success) {
  setItems(result.data) // TypeScript knows data exists
} else {
  setError(result.error) // TypeScript knows error exists
}
```

## Scope
- **Converted:** `github.ts`, `user-presets.ts` (client-consumed actions)
- **Not converted (intentional):** `board.ts` core functions (used by server components), `shared-project-info.ts` (used by both), `auth.ts` (redirect-based). These can follow in future PRs.

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes (85 files, 1202 tests)
- [ ] `pnpm build` passes
- [ ] Verify AddRepositoryCombobox fetches repos correctly
- [ ] Verify NoteModal loads user presets
- [ ] Verify CreateLinkTypeDialog creates presets

Closes #68