### PR TITLE
fix: remove dead loading/error Redux state from boardSlice (#76)

### DIFF
--- a/src/components/Board/KanbanBoard.stories.tsx
+++ b/src/components/Board/KanbanBoard.stories.tsx
@@ -23,11 +23,7 @@ import { useDispatch } from 'react-redux'
 import { expect, waitFor } from 'storybook/test'
 
 import type { StatusListDomain, RepoCardForRedux } from '@/lib/models/domain'
-import {
-  setStatusLists,
-  setRepoCards,
-  setBoardError,
-} from '@/lib/redux/slices/boardSlice'
+import { setStatusLists, setRepoCards } from '@/lib/redux/slices/boardSlice'
 import { mockStatusLists, mockRepoCards } from '@/mocks/handlers/data'
 
 import { KanbanBoard } from './KanbanBoard'
@@ -72,8 +68,6 @@ function ReduxHydrator({
   const dispatch = useDispatch()
 
   useLayoutEffect(() => {
-    // Clear any persisted error state from localStorage
-    dispatch(setBoardError(null))
     // Hydrate Redux with mock board data
     dispatch(setStatusLists(transformedStatusLists))
     dispatch(setRepoCards(transformedRepoCards))

--- a/src/components/Board/KanbanBoard.tsx
+++ b/src/components/Board/KanbanBoard.tsx
@@ -25,7 +25,6 @@ import {
 } from '@dnd-kit/sortable'
 import * as Sentry from '@sentry/nextjs'
 import { motion, useReducedMotion } from 'framer-motion'
-import { AlertCircle } from 'lucide-react'
 import React, { useState, useEffect, memo, useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 
@@ -50,8 +49,6 @@ import {
   setRepoCards,
   selectStatusLists,
   selectRepoCards,
-  selectBoardLoading,
-  selectBoardError,
 } from '@/lib/redux/slices/boardSlice'
 import { useAppDispatch, useAppSelector } from '@/lib/redux/store'
 import type { CommentColor } from '@/lib/supabase/types'
@@ -156,20 +153,6 @@ const KanbanSkeleton = memo(() => {
 })
 KanbanSkeleton.displayName = 'KanbanSkeleton'
 
-// Error State Component
-const ErrorState = memo(({ message }: { message: string }) => {
-  return (
-    <div className="flex min-h-[400px] flex-col items-center justify-center p-8">
-      <AlertCircle className="text-destructive mb-4 h-16 w-16" />
-      <h3 className="text-foreground mb-2 text-xl font-semibold">
-        Something went wrong
-      </h3>
-      <p className="text-muted-foreground max-w-md text-center">{message}</p>
-    </div>
-  )
-})
-ErrorState.displayName = 'ErrorState'
-
 // Main Kanban Board Component
 export const KanbanBoard = memo<KanbanBoardProps>(
   ({
@@ -191,8 +174,6 @@ export const KanbanBoard = memo<KanbanBoardProps>(
     const dispatch = useAppDispatch()
     const statuses = useAppSelector(selectStatusLists)
     const cards = useAppSelector(selectRepoCards)
-    const loading = useAppSelector(selectBoardLoading)
-    const error = useAppSelector(selectBoardError)
 
     // Local state (temporary state not migrated to Redux)
     const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null)
@@ -769,20 +750,11 @@ export const KanbanBoard = memo<KanbanBoardProps>(
       }
     }
 
-    // Only show skeleton on initial load (no data yet)
-    // Not on subsequent refetches when data already exists (e.g., after note save)
-    if (loading && statuses.length === 0) {
+    // Show skeleton when no data loaded yet (e.g., initial hydration)
+    if (statuses.length === 0) {
       return (
         <div className="w-full p-6">
           <KanbanSkeleton />
-        </div>
-      )
-    }
-
-    if (error) {
-      return (
-        <div className="w-full p-6">
-          <ErrorState message={error} />
         </div>
       )
     }

--- a/src/lib/redux/slices/boardSlice.ts
+++ b/src/lib/redux/slices/boardSlice.ts
@@ -18,16 +18,12 @@ interface BoardState {
   activeBoard: SimplifiedBoard | null
   statusLists: StatusListDomain[]
   repoCards: RepoCardForRedux[]
-  loading: boolean
-  error: string | null
 }
 
 const initialState: BoardState = {
   activeBoard: null,
   statusLists: [],
   repoCards: [],
-  loading: false,
-  error: null,
 }
 
 export const boardSlice = createSlice({
@@ -59,12 +55,6 @@ export const boardSlice = createSlice({
         (card) => card.id !== action.payload,
       )
     },
-    /**
-     * Set error state (null to clear)
-     */
-    setBoardError: (state, action: PayloadAction<string | null>) => {
-      state.error = action.payload
-    },
   },
 })
 
@@ -74,7 +64,6 @@ export const {
   setRepoCards,
   addRepoCards,
   removeRepoCard,
-  setBoardError,
 } = boardSlice.actions
 
 export default boardSlice.reducer
@@ -84,7 +73,3 @@ export const selectStatusLists = (state: { board: BoardState }) =>
   state.board.statusLists
 export const selectRepoCards = (state: { board: BoardState }) =>
   state.board.repoCards
-export const selectBoardLoading = (state: { board: BoardState }) =>
-  state.board.loading
-export const selectBoardError = (state: { board: BoardState }) =>
-  state.board.error

--- a/src/tests/unit/components/Board/KanbanBoard.test.tsx
+++ b/src/tests/unit/components/Board/KanbanBoard.test.tsx
@@ -40,10 +40,19 @@ function createMockStore() {
     preloadedState: {
       board: {
         activeBoard: null,
-        statusLists: [],
+        statusLists: [
+          {
+            id: 'status-1',
+            title: 'To Do',
+            color: '#6B7280',
+            gridRow: 0,
+            gridCol: 0,
+            boardId: 'board-1',
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       },
@@ -538,12 +547,12 @@ describe('StatusColumn Auto-Height Classes', () => {
  * - ErrorState rendering when error occurs
  * - Normal board rendering when data is available
  */
-describe('KanbanBoard Loading and Error States', () => {
+describe('KanbanBoard Loading States', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should render loading skeleton when loading is true and no status lists', async () => {
+  it('should render skeleton when no status lists exist', async () => {
     const store = configureStore({
       reducer: {
         board: boardSlice,
@@ -553,8 +562,6 @@ describe('KanbanBoard Loading and Error States', () => {
           activeBoard: null,
           statusLists: [],
           repoCards: [],
-          loading: true,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -575,42 +582,7 @@ describe('KanbanBoard Loading and Error States', () => {
     })
   })
 
-  it('should render error state when error exists', async () => {
-    const store = configureStore({
-      reducer: {
-        board: boardSlice,
-      },
-      preloadedState: {
-        board: {
-          activeBoard: null,
-          statusLists: [],
-          repoCards: [],
-          loading: false,
-          error: 'Failed to load board data',
-          lastDragOperation: null,
-          undoHistory: [],
-        },
-      },
-    })
-
-    const { container, getByText } = render(
-      <Provider store={store}>
-        <KanbanBoard boardId="test-board" initialComments={{}} />
-      </Provider>,
-    )
-
-    // Wait for error state to render
-    await waitFor(() => {
-      expect(getByText('Something went wrong')).toBeInTheDocument()
-      expect(getByText('Failed to load board data')).toBeInTheDocument()
-    })
-
-    // Check error icon is present
-    const errorIcon = container.querySelector('.text-destructive')
-    expect(errorIcon).toBeInTheDocument()
-  })
-
-  it('should not show skeleton when loading but status lists exist', async () => {
+  it('should not show skeleton when status lists exist', async () => {
     const store = configureStore({
       reducer: {
         board: boardSlice,
@@ -631,8 +603,6 @@ describe('KanbanBoard Loading and Error States', () => {
             },
           ],
           repoCards: [],
-          loading: true,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -714,8 +684,6 @@ describe('KanbanBoard with Data', () => {
               updatedAt: '2024-01-01T00:00:00.000Z',
             },
           ],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -776,8 +744,6 @@ describe('KanbanBoard with Data', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -843,8 +809,6 @@ describe('KanbanBoard Callbacks', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -921,8 +885,6 @@ describe('KanbanBoard Initial Comments', () => {
               updatedAt: '2024-01-01T00:00:00.000Z',
             },
           ],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -981,8 +943,6 @@ describe('KanbanBoard Card Display Settings', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1035,8 +995,6 @@ describe('KanbanBoard Card Display Settings', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1102,8 +1060,6 @@ describe('KanbanBoard Undo Keyboard Shortcut', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1153,8 +1109,6 @@ describe('KanbanBoard Undo Keyboard Shortcut', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1213,8 +1167,6 @@ describe('KanbanBoard Undo Keyboard Shortcut', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1289,8 +1241,6 @@ describe('KanbanBoard DndContext Configuration', () => {
               updatedAt: '2024-01-01T00:00:00.000Z',
             },
           ],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1366,8 +1316,6 @@ describe('KanbanBoard Multi-Row Layout', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -1447,8 +1395,6 @@ describe('KanbanBoard Multi-Row Layout', () => {
             },
           ],
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },

--- a/src/tests/unit/redux/boardSlice.test.ts
+++ b/src/tests/unit/redux/boardSlice.test.ts
@@ -7,7 +7,7 @@
  * - setRepoCards action
  * - addRepoCards action (optimistic updates)
  * - removeRepoCard action
- * - selectStatusLists, selectRepoCards, selectBoardLoading, selectBoardError selectors
+ * - selectStatusLists, selectRepoCards selectors
  */
 
 import { describe, it, expect } from 'vitest'
@@ -21,8 +21,6 @@ import boardSlice, {
   setStatusLists,
   removeRepoCard,
   selectStatusLists,
-  selectBoardLoading,
-  selectBoardError,
 } from '@/lib/redux/slices/boardSlice'
 
 /**
@@ -71,8 +69,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -98,8 +94,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -124,8 +118,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -141,8 +133,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -179,8 +169,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -203,8 +191,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -227,8 +213,6 @@ describe('boardSlice', () => {
           activeBoard: null,
           statusLists: [],
           repoCards: cards,
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -249,8 +233,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -281,8 +263,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -315,8 +295,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -338,8 +316,6 @@ describe('boardSlice', () => {
         activeBoard: existingBoard,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -357,8 +333,6 @@ describe('boardSlice', () => {
         activeBoard: existingBoard,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -373,8 +347,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -396,8 +368,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -420,8 +390,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: existingStatuses,
         repoCards: [],
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -445,8 +413,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -463,8 +429,6 @@ describe('boardSlice', () => {
         activeBoard: null,
         statusLists: [],
         repoCards: existingCards,
-        loading: false,
-        error: null,
         lastDragOperation: null,
         undoHistory: [],
       }
@@ -486,8 +450,6 @@ describe('boardSlice', () => {
           activeBoard: null,
           statusLists: statuses,
           repoCards: [],
-          loading: false,
-          error: null,
           lastDragOperation: null,
           undoHistory: [],
         },
@@ -497,42 +459,6 @@ describe('boardSlice', () => {
 
       expect(result).toHaveLength(2)
       expect(result[0]!.title).toBe('Todo')
-    })
-  })
-
-  describe('selectBoardLoading selector', () => {
-    it('should return loading state', () => {
-      const state = {
-        board: {
-          activeBoard: null,
-          statusLists: [],
-          repoCards: [],
-          loading: true,
-          error: null,
-          lastDragOperation: null,
-          undoHistory: [],
-        },
-      }
-
-      expect(selectBoardLoading(state)).toBe(true)
-    })
-  })
-
-  describe('selectBoardError selector', () => {
-    it('should return error from state', () => {
-      const state = {
-        board: {
-          activeBoard: null,
-          statusLists: [],
-          repoCards: [],
-          loading: false,
-          error: 'Test error',
-          lastDragOperation: null,
-          undoHistory: [],
-        },
-      }
-
-      expect(selectBoardError(state)).toBe('Test error')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Remove dead `loading` and `error` fields from `BoardState` interface and initial state
- Remove `setBoardError` action, `selectBoardLoading` and `selectBoardError` selectors
- Remove unused `ErrorState` component and `AlertCircle` import from KanbanBoard
- Simplify skeleton display condition: show when `statuses.length === 0` (previously `loading && statuses.length === 0` where `loading` was always `false`)
- Update all test fixtures to remove dead state fields

These fields became vestigial after the Phase 4 migration to Server Component data fetching.

Closes #76

## Test plan
- [x] `pnpm test` — all 1199 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [ ] Verify KanbanBoard Storybook renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified board state management by removing separate error state tracking and loading indicators. The skeleton loader now displays consistently when status lists are unavailable, reducing complexity in the board initialization flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->