### PR TITLE
refactor: extract shared StatusList mapper (#79)

### DIFF
--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -10,6 +10,7 @@
 import * as Sentry from '@sentry/nextjs'
 
 import { withAuth } from '@/lib/actions/auth-guard'
+import { toStatusListDomain } from '@/lib/actions/mappers'
 import type {
   StatusListDomain,
   RepoCardDomain,
@@ -27,7 +28,6 @@ import {
   gridPositionSchema,
 } from '@/lib/validations/board'
 
-type StatusListRow = Tables<'statuslist'>
 type RepoCardRow = Tables<'repocard'>
 
 // ========================================
@@ -58,16 +58,7 @@ export async function getStatusLists(
   }
 
   // Convert DB rows to domain model
-  return (data || []).map((row: StatusListRow) => ({
-    id: row.id,
-    title: row.name,
-    color: row.color ?? '#6B7280',
-    gridRow: row.grid_row ?? 0,
-    gridCol: row.grid_col ?? 0,
-    boardId: row.board_id,
-    createdAt: row.created_at ?? new Date().toISOString(),
-    updatedAt: row.updated_at ?? new Date().toISOString(),
-  }))
+  return (data || []).map(toStatusListDomain)
 }
 
 /**
@@ -135,16 +126,7 @@ export async function createDefaultStatusLists(
     throw new Error('Failed to create default status lists')
   }
 
-  return (data || []).map((row: StatusListRow) => ({
-    id: row.id,
-    title: row.name,
-    color: row.color ?? '#6B7280',
-    gridRow: row.grid_row ?? 0,
-    gridCol: row.grid_col ?? 0,
-    boardId: row.board_id,
-    createdAt: row.created_at ?? new Date().toISOString(),
-    updatedAt: row.updated_at ?? new Date().toISOString(),
-  }))
+  return (data || []).map(toStatusListDomain)
 }
 
 /**
@@ -199,16 +181,7 @@ export async function createStatusList(
     throw new Error('Failed to create status list')
   }
 
-  return {
-    id: data.id,
-    title: data.name,
-    color: data.color ?? '#6B7280',
-    gridRow: data.grid_row ?? 0,
-    gridCol: data.grid_col ?? 0,
-    boardId: data.board_id,
-    createdAt: data.created_at ?? new Date().toISOString(),
-    updatedAt: data.updated_at ?? new Date().toISOString(),
-  }
+  return toStatusListDomain(data)
 }
 
 /**

--- a/src/lib/actions/mappers.ts
+++ b/src/lib/actions/mappers.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain Model Mappers
+ *
+ * Converts Supabase database rows to domain models used in the application.
+ * Centralizes mapping logic to avoid duplication across server actions.
+ */
+
+import type { StatusListDomain } from '@/lib/models/domain'
+import type { Tables } from '@/lib/supabase/types'
+
+type StatusListRow = Tables<'statuslist'>
+
+/**
+ * Convert a Supabase statuslist row to the application domain model.
+ *
+ * @param row - Raw database row from the statuslist table
+ * @returns StatusListDomain with fallback defaults for nullable columns
+ *
+ * @example
+ * const domain = toStatusListDomain(row)
+ * // => { id: '...', title: 'Todo', color: '#6B7280', gridRow: 0, gridCol: 0, ... }
+ */
+export function toStatusListDomain(row: StatusListRow): StatusListDomain {
+  return {
+    id: row.id,
+    title: row.name,
+    color: row.color ?? '#6B7280',
+    gridRow: row.grid_row ?? 0,
+    gridCol: row.grid_col ?? 0,
+    boardId: row.board_id,
+    createdAt: row.created_at ?? new Date().toISOString(),
+    updatedAt: row.updated_at ?? new Date().toISOString(),
+  }
+}


### PR DESCRIPTION
## Summary
- Create `toStatusListDomain()` mapper in `src/lib/actions/mappers.ts`
- Replace 3 identical `StatusListRow → StatusListDomain` mapping blocks in `board.ts`
- Ensures consistent default values (color, gridRow, gridCol, timestamps) in one place

Closes #79

## Test plan
- [x] `pnpm test` — all 1202 tests pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean (via pre-commit hook)