### PR TITLE
test: add account deletion dialog test coverage (#70)

### DIFF
--- a/e2e/logged-in/account-deletion.spec.ts
+++ b/e2e/logged-in/account-deletion.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Account Deletion E2E Tests
+ *
+ * Tests the account deletion dialog flow:
+ * - Navigate to /account, open dialog
+ * - Delete button disabled by default
+ * - Typing "DELETE" enables the confirm button
+ * - Cancel closes the dialog
+ *
+ * UI-only validation — no actual deletion (server action needs real session)
+ */
+
+import { test, expect } from '../fixtures/coverage'
+
+test.describe('Account Deletion Dialog', () => {
+  test.use({ storageState: 'e2e/.auth/user.json' })
+
+  test('should display delete account button on account page', async ({
+    page,
+  }) => {
+    await page.goto('/account')
+
+    const deleteButton = page.getByTestId('delete-account-button')
+    await expect(deleteButton).toBeVisible()
+    await expect(deleteButton).toHaveText('Delete Account')
+  })
+
+  test('should open dialog with disabled confirm button', async ({ page }) => {
+    await page.goto('/account')
+
+    // Open the delete account dialog
+    await page.getByTestId('delete-account-button').click()
+
+    // Dialog should appear
+    const dialog = page.getByTestId('delete-account-dialog')
+    await expect(dialog).toBeVisible()
+
+    // Confirm button should be disabled by default
+    const confirmButton = page.getByTestId('confirm-delete-button')
+    await expect(confirmButton).toBeDisabled()
+
+    // Cancel button should be enabled
+    const cancelButton = page.getByTestId('cancel-delete-button')
+    await expect(cancelButton).toBeEnabled()
+  })
+
+  test('should enable confirm button after typing DELETE', async ({ page }) => {
+    await page.goto('/account')
+
+    await page.getByTestId('delete-account-button').click()
+    await expect(page.getByTestId('delete-account-dialog')).toBeVisible()
+
+    // Type "DELETE" in the confirmation input
+    const input = page.getByTestId('delete-confirmation-input')
+    await input.fill('DELETE')
+
+    // Confirm button should now be enabled
+    const confirmButton = page.getByTestId('confirm-delete-button')
+    await expect(confirmButton).toBeEnabled()
+  })
+
+  test('should keep confirm button disabled with partial input', async ({
+    page,
+  }) => {
+    await page.goto('/account')
+
+    await page.getByTestId('delete-account-button').click()
+    await expect(page.getByTestId('delete-account-dialog')).toBeVisible()
+
+    // Type partial text
+    const input = page.getByTestId('delete-confirmation-input')
+    await input.fill('DEL')
+
+    // Confirm button should still be disabled
+    const confirmButton = page.getByTestId('confirm-delete-button')
+    await expect(confirmButton).toBeDisabled()
+  })
+
+  test('should close dialog when cancel is clicked', async ({ page }) => {
+    await page.goto('/account')
+
+    await page.getByTestId('delete-account-button').click()
+    const dialog = page.getByTestId('delete-account-dialog')
+    await expect(dialog).toBeVisible()
+
+    // Click cancel
+    await page.getByTestId('cancel-delete-button').click()
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible()
+  })
+})

--- a/src/components/Modals/DeleteAccountDialog.stories.tsx
+++ b/src/components/Modals/DeleteAccountDialog.stories.tsx
@@ -1,0 +1,127 @@
+/**
+ * DeleteAccountDialog Component Stories
+ *
+ * Tests the account deletion confirmation dialog:
+ * - Default open state with disabled delete button
+ * - Typing "DELETE" enables the confirm button
+ * - Cancel button closes the dialog
+ * - Accessible structure verified via a11y checks
+ */
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+
+import { DeleteAccountDialog } from './DeleteAccountDialog'
+
+const meta = {
+  title: 'Modals/DeleteAccountDialog',
+  component: DeleteAccountDialog,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DeleteAccountDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Default state: dialog open, delete button disabled
+ */
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+  },
+  play: async ({ canvasElement: _canvasElement }) => {
+    // Dialog renders in a portal, query the document body
+    const body = within(document.body)
+
+    await waitFor(
+      () => {
+        expect(body.getByTestId('delete-account-dialog')).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
+
+    // Delete button should be disabled by default
+    const deleteButton = body.getByTestId('confirm-delete-button')
+    expect(deleteButton).toBeDisabled()
+
+    // Cancel button should be enabled
+    const cancelButton = body.getByTestId('cancel-delete-button')
+    expect(cancelButton).toBeEnabled()
+  },
+}
+
+/**
+ * After typing "DELETE", the confirm button becomes enabled
+ */
+export const WithConfirmationTyped: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+  },
+  play: async () => {
+    const body = within(document.body)
+
+    await waitFor(
+      () => {
+        expect(
+          body.getByTestId('delete-confirmation-input'),
+        ).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
+
+    const input = body.getByTestId('delete-confirmation-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'DELETE')
+
+    // Button should now be enabled
+    await waitFor(() => {
+      const deleteButton = body.getByTestId('confirm-delete-button')
+      expect(deleteButton).toBeEnabled()
+    })
+  },
+}
+
+/**
+ * Partial input keeps button disabled
+ */
+export const PartialInput: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => {},
+  },
+  play: async () => {
+    const body = within(document.body)
+
+    await waitFor(
+      () => {
+        expect(
+          body.getByTestId('delete-confirmation-input'),
+        ).toBeInTheDocument()
+      },
+      { timeout: 3000 },
+    )
+
+    const input = body.getByTestId('delete-confirmation-input')
+    await userEvent.clear(input)
+    await userEvent.type(input, 'DEL')
+
+    // Button should still be disabled
+    const deleteButton = body.getByTestId('confirm-delete-button')
+    expect(deleteButton).toBeDisabled()
+  },
+}
+
+/**
+ * Dialog in closed state renders nothing
+ */
+export const Closed: Story = {
+  args: {
+    isOpen: false,
+    onClose: () => {},
+  },
+}


### PR DESCRIPTION
## Summary
- Add Storybook stories for `DeleteAccountDialog` with 4 stories: Default, WithConfirmationTyped, PartialInput, Closed
- Add E2E tests for account deletion flow: dialog display, button states, input validation, cancel flow
- UI-only validation (no actual deletion — server action needs real session)

Closes #70

## Test plan
- [ ] `pnpm test` — Storybook stories pass
- [ ] `pnpm e2e` — New E2E tests pass
- [ ] Verify dialog renders in Storybook