### PR TITLE
refactor: extract shared CommentSection component (#66)

### DIFF
--- a/src/app/maintenance/MaintenanceClient.tsx
+++ b/src/app/maintenance/MaintenanceClient.tsx
@@ -31,15 +31,10 @@ import {
   useRef,
   useTransition,
   useEffect,
-  Activity,
 } from 'react'
 
-import { CommentActionsMenu } from '@/components/Board/CommentActionsMenu'
-import { CommentDisplay } from '@/components/Board/CommentDisplay'
-import {
-  CommentInlineEdit,
-  type CommentSaveOptions,
-} from '@/components/Board/CommentInlineEdit'
+import { type CommentSaveOptions } from '@/components/Board/CommentInlineEdit'
+import { CommentSection } from '@/components/Board/CommentSection'
 import { NoteModal } from '@/components/Modals/NoteModal'
 import {
   RestoreToBoardDialog,
@@ -532,57 +527,21 @@ export const MaintenanceClient = memo(function MaintenanceClient({
                           {repo.repo_owner}
                         </p>
 
-                        {/* Inline Comment (same as Board RepoCard) */}
-                        <Activity
-                          mode={
-                            editingCommentId === repo.id ? 'visible' : 'hidden'
+                        {/* Inline Comment (shared CommentSection) */}
+                        <CommentSection
+                          comment={comments[repo.id]?.comment}
+                          color={comments[repo.id]?.color}
+                          isEditing={editingCommentId === repo.id}
+                          onStartEdit={() => handleCommentClick(repo.id)}
+                          onSave={async (newComment, options) =>
+                            handleCommentSave(repo.id, newComment, options)
                           }
-                        >
-                          <CommentInlineEdit
-                            initialValue={comments[repo.id]?.comment ?? ''}
-                            onSave={async (newComment, options) =>
-                              handleCommentSave(repo.id, newComment, options)
-                            }
-                            onCancel={handleCommentCancel}
-                            style={{
-                              borderColor:
-                                comments[repo.id]?.color ?? 'neutral',
-                            }}
-                          />
-                        </Activity>
-                        <Activity
-                          mode={
-                            editingCommentId === repo.id ? 'hidden' : 'visible'
+                          onCancel={handleCommentCancel}
+                          onColorChange={async (color) =>
+                            handleColorChange(repo.id, color)
                           }
-                        >
-                          <CommentDisplay
-                            comment={comments[repo.id]?.comment}
-                            onClick={() => handleCommentClick(repo.id)}
-                            style={{
-                              borderColor:
-                                comments[repo.id]?.color ?? 'neutral',
-                            }}
-                            showEmptyState={true}
-                            renderActions={
-                              comments[repo.id]?.comment
-                                ? () => (
-                                    <CommentActionsMenu
-                                      onEdit={() => handleCommentClick(repo.id)}
-                                      onColorChange={async (color) =>
-                                        handleColorChange(repo.id, color)
-                                      }
-                                      onDelete={async () =>
-                                        handleCommentDelete(repo.id)
-                                      }
-                                      currentColor={
-                                        comments[repo.id]?.color ?? 'neutral'
-                                      }
-                                    />
-                                  )
-                                : undefined
-                            }
-                          />
-                        </Activity>
+                          onDelete={async () => handleCommentDelete(repo.id)}
+                        />
 
                         {/* Meta + Note Button */}
                         <div className="flex items-center justify-between pt-2">
@@ -699,58 +658,21 @@ export const MaintenanceClient = memo(function MaintenanceClient({
                       </div>
 
                       {/* Inline Comment for List view */}
-                      <div className="mt-3">
-                        <Activity
-                          mode={
-                            editingCommentId === repo.id ? 'visible' : 'hidden'
-                          }
-                        >
-                          <CommentInlineEdit
-                            initialValue={comments[repo.id]?.comment ?? ''}
-                            onSave={async (newComment, options) =>
-                              handleCommentSave(repo.id, newComment, options)
-                            }
-                            onCancel={handleCommentCancel}
-                            style={{
-                              borderColor:
-                                comments[repo.id]?.color ?? 'neutral',
-                            }}
-                          />
-                        </Activity>
-                        <Activity
-                          mode={
-                            editingCommentId === repo.id ? 'hidden' : 'visible'
-                          }
-                        >
-                          <CommentDisplay
-                            comment={comments[repo.id]?.comment}
-                            onClick={() => handleCommentClick(repo.id)}
-                            style={{
-                              borderColor:
-                                comments[repo.id]?.color ?? 'neutral',
-                            }}
-                            showEmptyState={true}
-                            renderActions={
-                              comments[repo.id]?.comment
-                                ? () => (
-                                    <CommentActionsMenu
-                                      onEdit={() => handleCommentClick(repo.id)}
-                                      onColorChange={async (color) =>
-                                        handleColorChange(repo.id, color)
-                                      }
-                                      onDelete={async () =>
-                                        handleCommentDelete(repo.id)
-                                      }
-                                      currentColor={
-                                        comments[repo.id]?.color ?? 'neutral'
-                                      }
-                                    />
-                                  )
-                                : undefined
-                            }
-                          />
-                        </Activity>
-                      </div>
+                      <CommentSection
+                        comment={comments[repo.id]?.comment}
+                        color={comments[repo.id]?.color}
+                        isEditing={editingCommentId === repo.id}
+                        onStartEdit={() => handleCommentClick(repo.id)}
+                        onSave={async (newComment, options) =>
+                          handleCommentSave(repo.id, newComment, options)
+                        }
+                        onCancel={handleCommentCancel}
+                        onColorChange={async (color) =>
+                          handleColorChange(repo.id, color)
+                        }
+                        onDelete={async () => handleCommentDelete(repo.id)}
+                        className="mt-3"
+                      />
                     </motion.div>
                   ))}
                 </div>

--- a/src/components/Board/CommentSection.tsx
+++ b/src/components/Board/CommentSection.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import React, { Activity, memo } from 'react'
+
+import type { CommentColor } from '@/lib/supabase/types'
+
+import { CommentActionsMenu } from './CommentActionsMenu'
+import { CommentDisplay, type CommentStyleSettings } from './CommentDisplay'
+import { CommentInlineEdit, type CommentSaveOptions } from './CommentInlineEdit'
+
+interface CommentSectionProps {
+  /** Comment text */
+  comment?: string | null
+  /** Comment border color */
+  color?: CommentColor
+  /** Whether the comment is in edit mode */
+  isEditing: boolean
+  /** Callback to enter edit mode */
+  onStartEdit: () => void
+  /** Callback to save the comment */
+  onSave: (newComment: string, options: CommentSaveOptions) => Promise<void>
+  /** Callback to cancel editing */
+  onCancel: () => void
+  /** Callback to change comment color */
+  onColorChange: (color: CommentColor) => void
+  /** Callback to delete the comment */
+  onDelete: () => void
+  /** Optional style overrides for comment display */
+  style?: Partial<CommentStyleSettings>
+  /** Optional className for wrapper */
+  className?: string
+}
+
+/**
+ * Shared comment section with Activity-toggled inline edit / display.
+ *
+ * Encapsulates the CommentInlineEdit ↔ CommentDisplay toggle pattern
+ * that is repeated across RepoCard (board) and MaintenanceClient (grid + list).
+ *
+ * @example
+ * <CommentSection
+ *   comment={commentData?.comment}
+ *   color={commentData?.color}
+ *   isEditing={isEditingComment}
+ *   onStartEdit={handleCommentClick}
+ *   onSave={handleCommentSave}
+ *   onCancel={handleCommentCancel}
+ *   onColorChange={handleColorChange}
+ *   onDelete={handleCommentDelete}
+ * />
+ */
+export const CommentSection = memo<CommentSectionProps>(
+  function CommentSection({
+    comment,
+    color = 'neutral',
+    isEditing,
+    onStartEdit,
+    onSave,
+    onCancel,
+    onColorChange,
+    onDelete,
+    style,
+    className,
+  }) {
+    const mergedStyle: Partial<CommentStyleSettings> = {
+      borderColor: color,
+      ...style,
+    }
+
+    return (
+      <div className={className}>
+        <Activity mode={isEditing ? 'visible' : 'hidden'}>
+          <CommentInlineEdit
+            initialValue={comment ?? ''}
+            onSave={onSave}
+            onCancel={onCancel}
+            style={mergedStyle}
+          />
+        </Activity>
+        <Activity mode={isEditing ? 'hidden' : 'visible'}>
+          <CommentDisplay
+            comment={comment}
+            onClick={onStartEdit}
+            style={mergedStyle}
+            showEmptyState={true}
+            renderActions={
+              comment
+                ? () => (
+                    <CommentActionsMenu
+                      onEdit={onStartEdit}
+                      onColorChange={onColorChange}
+                      onDelete={onDelete}
+                      currentColor={color}
+                    />
+                  )
+                : undefined
+            }
+          />
+        </Activity>
+      </div>
+    )
+  },
+)

--- a/src/components/Board/RepoCard.tsx
+++ b/src/components/Board/RepoCard.tsx
@@ -3,7 +3,7 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { Calendar, Paperclip, StickyNote } from 'lucide-react'
-import React, { Activity, memo, useCallback, useState } from 'react'
+import React, { memo, useCallback, useState } from 'react'
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Badge } from '@/components/ui/badge'
@@ -12,9 +12,8 @@ import type { CommentData } from '@/lib/actions/project-info'
 import type { CommentColor } from '@/lib/supabase/types'
 import type { CommentTextSettings } from '@/lib/types/board-settings'
 
-import { CommentActionsMenu } from './CommentActionsMenu'
-import { CommentDisplay } from './CommentDisplay'
-import { CommentInlineEdit, type CommentSaveOptions } from './CommentInlineEdit'
+import { type CommentSaveOptions } from './CommentInlineEdit'
+import { CommentSection } from './CommentSection'
 import { OverflowMenu } from './OverflowMenu'
 
 // Types
@@ -242,46 +241,18 @@ export const RepoCard = memo<RepoCardProps>(
               )}
 
               {/* Inline Comment (Card-in-Card style) */}
-              {/* Using React 19 <Activity /> to preserve CommentInlineEdit state */}
-              {/* When parent re-renders, conditional rendering would unmount/remount */}
-              {/* <Activity mode="hidden"> keeps DOM but hides, preserving state */}
               {showComment && (
-                <>
-                  <Activity mode={isEditingComment ? 'visible' : 'hidden'}>
-                    <CommentInlineEdit
-                      initialValue={commentData?.comment ?? ''}
-                      onSave={handleCommentSave}
-                      onCancel={handleCommentCancel}
-                      style={{
-                        borderColor: commentData?.color ?? 'neutral',
-                        ...commentText,
-                      }}
-                    />
-                  </Activity>
-                  <Activity mode={isEditingComment ? 'hidden' : 'visible'}>
-                    <CommentDisplay
-                      comment={commentData?.comment}
-                      onClick={handleCommentClick}
-                      style={{
-                        borderColor: commentData?.color ?? 'neutral',
-                        ...commentText,
-                      }}
-                      showEmptyState={true}
-                      renderActions={
-                        commentData?.comment
-                          ? () => (
-                              <CommentActionsMenu
-                                onEdit={handleCommentClick}
-                                onColorChange={handleColorChange}
-                                onDelete={handleCommentDelete}
-                                currentColor={commentData?.color ?? 'neutral'}
-                              />
-                            )
-                          : undefined
-                      }
-                    />
-                  </Activity>
-                </>
+                <CommentSection
+                  comment={commentData?.comment}
+                  color={commentData?.color}
+                  isEditing={isEditingComment}
+                  onStartEdit={handleCommentClick}
+                  onSave={handleCommentSave}
+                  onCancel={handleCommentCancel}
+                  onColorChange={handleColorChange}
+                  onDelete={handleCommentDelete}
+                  style={commentText}
+                />
               )}
 
               <div className="flex items-center justify-between pt-2">


### PR DESCRIPTION
## Summary
- Extract duplicated Activity toggle + CommentInlineEdit + CommentDisplay + CommentActionsMenu pattern into `CommentSection` component
- Replace 3 identical blocks: RepoCard (board), MaintenanceClient grid view, MaintenanceClient list view
- Net ~100 lines saved while improving maintainability

Closes #66

## Test plan
- [ ] `pnpm test` — All 1202 tests pass
- [ ] `pnpm lint && pnpm typecheck && pnpm build` — Clean
- [ ] `pnpm e2e` — Comment inline edit, comment display, comment color tests pass
- [ ] Verify board RepoCard comments work in Storybook
- [ ] Verify maintenance grid/list view comments work