### PR TITLE
fix: storybook TestFullWorkflow focus issue in CI

### DIFF
--- a/src/components/Board/CommentEditingWorkflow.stories.tsx
+++ b/src/components/Board/CommentEditingWorkflow.stories.tsx
@@ -744,6 +744,9 @@ export const TestFullWorkflow: Story = {
       })
 
       const textarea = await canvas.findByTestId('comment-textarea')
+      // Activity keeps component mounted — auto-focus effect may not re-fire.
+      // Explicitly click to ensure focus before clearing.
+      await userEvent.click(textarea)
       await userEvent.clear(textarea)
       await userEvent.type(textarea, 'Updated comment')
       // Use save button instead of Enter key


### PR DESCRIPTION
## Summary
- Fix flaky `TestFullWorkflow` storybook interaction test that fails in CI with "The element to be cleared could not be focused"
- Root cause: `<Activity>` component keeps `CommentInlineEdit` mounted but hidden. When switching from `hidden` to `visible`, the auto-focus `useEffect` does not re-fire (dependency `autoFocus` hasn't changed), so the textarea becomes visible but unfocused
- Fix: Add explicit `userEvent.click(textarea)` before `userEvent.clear(textarea)` to ensure focus

## Test plan
- [x] `pnpm test` passes locally (1282/1282 tests)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] CI unit tests pass (the actual fix for the failure)
- [ ] CI E2E tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved component interaction reliability by enhancing focus behavior during editing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->