### PR TITLE
refactor: remove theme section from Settings page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,8 @@ This application requires GitHub authentication to access any functionality beyo
 
 ## Critical Rules
 
-- 🔴 **Always run before ending session as parallel:** `pnpm test`, `pnpm lint`, `pnpm build`, `pnpm typecheck`, `pnpm e2e`
+- 🔴 **Always run before ending session as parallel:** `pnpm test`, `pnpm lint`, `pnpm build`, `pnpm typecheck`, `pnpm e2e:parallel`
+- 🔴 **E2E execution:** Use `pnpm e2e:parallel` (fast, parallel shards). Fallback to `pnpm e2e` only if parallel fails.
 - 🔴 **Vercel project:** Use ONLY `laststance/gitbox` (ID: `prj_M4T9K5HjwFx0e9PIueEhOFn1UmUM`)
 
 ---
@@ -310,7 +311,10 @@ app/
 ### Running E2E Tests
 
 ```bash
-# Run Playwright tests (MSW auto-enabled)
+# Run Playwright tests in parallel (fast, recommended)
+pnpm e2e:parallel
+
+# Fallback: sequential run (if parallel fails)
 pnpm e2e
 
 # Run with headed browser (add --headed flag)

--- a/e2e/logged-in/settings.spec.ts
+++ b/e2e/logged-in/settings.spec.ts
@@ -1,8 +1,9 @@
 /**
  * Settings Page E2E Tests
  *
- * Tests for the settings page (theme, language, etc.)
- * Requires authentication
+ * Tests for the settings page (display settings).
+ * Theme selection is handled via sidebar ThemeToggle, not the settings page.
+ * Requires authentication.
  */
 
 import { test, expect } from '../fixtures/coverage'
@@ -21,40 +22,22 @@ test.describe('Settings Page (Authenticated)', () => {
     await expect(heading).toBeVisible()
   })
 
-  test('should display theme options', async ({ page }) => {
+  test('should display display settings', async ({ page }) => {
     await page.goto('/settings')
 
-    // Look for theme section
-    const themeSection = page.getByText(/theme|appearance/i)
-    await expect(themeSection.first()).toBeVisible()
+    // Look for display section
+    const displaySection = page.getByText(/display/i)
+    await expect(displaySection.first()).toBeVisible()
 
-    // Should have theme selection options
-    const themeOptions = page.locator(
-      '[data-testid="theme-option"], button:has-text("midnight"), button:has-text("sunrise")',
-    )
-    await expect(themeOptions.first()).toBeVisible()
-  })
+    // Should have compact mode toggle
+    const compactToggle = page.getByRole('switch', { name: /compact mode/i })
+    await expect(compactToggle).toBeVisible()
 
-  test('should change theme when selecting option', async ({ page }) => {
-    await page.goto('/settings')
-
-    // Get initial body classes
-    const initialClasses = await page.locator('html').getAttribute('class')
-
-    // Click a different theme option
-    const themeButton = page.locator(
-      'button:has-text("midnight"), button:has-text("graphite"), [data-testid="theme-midnight"]',
-    )
-
-    if (await themeButton.first().isVisible()) {
-      await themeButton.first().click()
-
-      // Wait for theme change by verifying class attribute changes
-      await expect(async () => {
-        const newClasses = await page.locator('html').getAttribute('class')
-        expect(newClasses).not.toBe(initialClasses)
-      }).toPass({ timeout: 5000 })
-    }
+    // Should have show card metadata toggle
+    const metadataToggle = page.getByRole('switch', {
+      name: /show card metadata/i,
+    })
+    await expect(metadataToggle).toBeVisible()
   })
 
   test('should display language options', async ({ page }) => {

--- a/e2e/logged-in/theme-persistence.spec.ts
+++ b/e2e/logged-in/theme-persistence.spec.ts
@@ -1,28 +1,44 @@
 /**
  * Theme Persistence E2E Tests
  *
- * Tests theme selection persistence via Redux Storage Middleware
- * Verifies theme survives page reload and is correctly applied to DOM
+ * Tests theme selection persistence via Redux Storage Middleware.
+ * Theme is selected via sidebar ThemeToggle dropdown.
+ * Verifies theme survives page reload and is correctly applied to DOM.
  */
 
 import { test, expect } from '../fixtures/coverage'
+
+/**
+ * Helper: select a theme via the sidebar ThemeToggle dropdown.
+ * @param page - Playwright page
+ * @param themeName - Display name of the theme (e.g., "Midnight", "Sunrise")
+ */
+async function selectThemeFromSidebar(
+  page: import('@playwright/test').Page,
+  themeName: string,
+) {
+  const themeButton = page.locator('aside button:has-text("Theme")')
+  await expect(themeButton).toBeVisible()
+  await themeButton.click()
+
+  const menuItem = page
+    .locator('[role="menuitem"]')
+    .filter({ hasText: themeName })
+  await expect(menuItem).toBeVisible()
+  await menuItem.click()
+}
 
 test.describe('Theme Persistence (Authenticated)', () => {
   test.use({ storageState: 'e2e/.auth/user.json' })
 
   test('should persist midnight theme after page reload', async ({ page }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting the settings page content is ready
     const html = page.locator('html')
 
-    // Select midnight theme (dark theme)
-    const midnightButton = page.locator('button').filter({
-      has: page.locator('span:text-is("Midnight")'),
-    })
-    await expect(midnightButton).toBeVisible()
-    await midnightButton.click()
+    // Select midnight theme (dark theme) via sidebar
+    await selectThemeFromSidebar(page, 'Midnight')
 
     // Verify theme is applied immediately
     await expect(html).toHaveAttribute('data-theme', 'midnight', {
@@ -60,17 +76,11 @@ test.describe('Theme Persistence (Authenticated)', () => {
   })
 
   test('should persist sunrise theme after page reload', async ({ page }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting theme button is visible
-    const sunriseButton = page.locator('button').filter({
-      has: page.locator('span:text-is("Sunrise")'),
-    })
-    await expect(sunriseButton).toBeVisible()
-
-    // Select sunrise theme (light theme)
-    await sunriseButton.click()
+    // Select sunrise theme (light theme) via sidebar
+    await selectThemeFromSidebar(page, 'Sunrise')
 
     // Verify theme is applied
     const html = page.locator('html')
@@ -110,17 +120,11 @@ test.describe('Theme Persistence (Authenticated)', () => {
   })
 
   test('should persist system theme after page reload', async ({ page }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting theme button is visible
-    const systemButton = page.locator('button').filter({
-      has: page.locator('span:text-is("System")'),
-    })
-    await expect(systemButton).toBeVisible()
-
-    // Select system theme
-    await systemButton.click()
+    // Select system theme via sidebar
+    await selectThemeFromSidebar(page, 'System')
 
     // System theme should NOT have data-theme attribute (or empty)
     const html = page.locator('html')
@@ -145,17 +149,11 @@ test.describe('Theme Persistence (Authenticated)', () => {
   test('should persist theme when navigating between pages', async ({
     page,
   }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting theme button is visible
-    const graphiteButton = page.locator('button').filter({
-      has: page.locator('span:text-is("Graphite")'),
-    })
-    await expect(graphiteButton).toBeVisible()
-
-    // Select graphite theme (dark theme)
-    await graphiteButton.click()
+    // Select graphite theme (dark theme) via sidebar
+    await selectThemeFromSidebar(page, 'Graphite')
 
     // Verify theme applied
     const html = page.locator('html')
@@ -173,18 +171,18 @@ test.describe('Theme Persistence (Authenticated)', () => {
       expect(theme).toBe('graphite')
     }).toPass({ timeout: 5000 })
 
-    // Navigate to boards page
-    await page.goto('/boards')
+    // Navigate to settings page
+    await page.goto('/settings')
     await page.waitForLoadState('networkidle')
 
-    // Theme should persist on boards page
+    // Theme should persist on settings page
     await expect(html).toHaveAttribute('data-theme', 'graphite', {
       timeout: 5000,
     })
     await expect(html).toHaveClass(/dark/)
 
-    // Navigate back to settings
-    await page.goto('/settings')
+    // Navigate back to boards
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
     // Theme should still be graphite
@@ -198,17 +196,11 @@ test.describe('Theme Persistence (Authenticated)', () => {
     // Emulate dark color scheme
     await page.emulateMedia({ colorScheme: 'dark' })
 
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting theme button is visible
-    const systemButton = page.locator('button').filter({
-      has: page.locator('span:text-is("System")'),
-    })
-    await expect(systemButton).toBeVisible()
-
-    // Select system theme
-    await systemButton.click()
+    // Select system theme via sidebar
+    await selectThemeFromSidebar(page, 'System')
 
     // Should have dark class (following system preference)
     const html = page.locator('html')
@@ -224,17 +216,11 @@ test.describe('Theme Persistence (Authenticated)', () => {
     // Emulate light color scheme
     await page.emulateMedia({ colorScheme: 'light' })
 
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for hydration by asserting theme button is visible
-    const systemButton = page.locator('button').filter({
-      has: page.locator('span:text-is("System")'),
-    })
-    await expect(systemButton).toBeVisible()
-
-    // Select system theme
-    await systemButton.click()
+    // Select system theme via sidebar
+    await selectThemeFromSidebar(page, 'System')
 
     // Should NOT have dark class (following system preference)
     const html = page.locator('html')

--- a/e2e/logged-in/theme-visual-application.spec.ts
+++ b/e2e/logged-in/theme-visual-application.spec.ts
@@ -3,6 +3,7 @@
  *
  * Verifies that all 14 themes actually change the visual appearance
  * by checking computed CSS variables on the <html> element.
+ * Theme is selected via sidebar ThemeToggle dropdown.
  *
  * This catches the CSS specificity bug where data-theme attribute was set
  * but :root/:dark selectors overrode theme variables due to cascade order.
@@ -35,6 +36,36 @@ const THEMES = {
   ],
 } as const
 
+/**
+ * Helper: select a theme via the sidebar ThemeToggle dropdown.
+ * @param page - Playwright page
+ * @param themeName - Display name of the theme (e.g., "Midnight", "Sunrise")
+ */
+async function selectThemeFromSidebar(
+  page: import('@playwright/test').Page,
+  themeName: string,
+) {
+  const themeButton = page.locator('aside button:has-text("Theme")')
+  await expect(themeButton).toBeVisible()
+
+  // Ensure any previously open dropdown is closed before opening a new one
+  const existingMenu = page.locator('[role="menu"]')
+  if (await existingMenu.isVisible().catch(() => false)) {
+    await expect(existingMenu).not.toBeVisible({ timeout: 3000 })
+  }
+
+  await themeButton.click()
+
+  const menuItem = page
+    .locator('[role="menuitem"]')
+    .filter({ hasText: themeName })
+  await expect(menuItem).toBeVisible({ timeout: 5000 })
+  await menuItem.click()
+
+  // Wait for dropdown to close after selection
+  await expect(existingMenu).not.toBeVisible({ timeout: 3000 })
+}
+
 test.describe('Theme Visual Application', () => {
   test.use({ storageState: 'e2e/.auth/user.json' })
 
@@ -64,23 +95,19 @@ test.describe('Theme Visual Application', () => {
     test(`light theme "${theme.name}" should visually change background`, async ({
       page,
     }) => {
-      await page.goto('/settings')
+      await page.goto('/boards')
       await page.waitForLoadState('networkidle')
 
-      // Wait for settings page to be fully rendered
-      await expect(
-        page.getByRole('heading', { name: /settings/i }),
-      ).toBeVisible({ timeout: 10000 })
+      // Wait for sidebar to be fully rendered
+      await expect(page.locator('aside button:has-text("Theme")')).toBeVisible({
+        timeout: 10000,
+      })
 
       // Capture initial (system default) background
       const initialBg = await getBodyBgColor(page)
 
-      // Select the theme
-      const themeButton = page.locator('button').filter({
-        has: page.locator(`span:text-is("${theme.name}")`),
-      })
-      await expect(themeButton).toBeVisible()
-      await themeButton.click()
+      // Select the theme via sidebar dropdown
+      await selectThemeFromSidebar(page, theme.name)
 
       // Verify data-theme attribute is set
       const html = page.locator('html')
@@ -106,23 +133,19 @@ test.describe('Theme Visual Application', () => {
     test(`dark theme "${theme.name}" should visually change background`, async ({
       page,
     }) => {
-      await page.goto('/settings')
+      await page.goto('/boards')
       await page.waitForLoadState('networkidle')
 
-      // Wait for settings page to be fully rendered
-      await expect(
-        page.getByRole('heading', { name: /settings/i }),
-      ).toBeVisible({ timeout: 10000 })
+      // Wait for sidebar to be fully rendered
+      await expect(page.locator('aside button:has-text("Theme")')).toBeVisible({
+        timeout: 10000,
+      })
 
       // Capture initial (system default) background
       const initialBg = await getBodyBgColor(page)
 
-      // Select the theme
-      const themeButton = page.locator('button').filter({
-        has: page.locator(`span:text-is("${theme.name}")`),
-      })
-      await expect(themeButton).toBeVisible()
-      await themeButton.click()
+      // Select the theme via sidebar dropdown
+      await selectThemeFromSidebar(page, theme.name)
 
       // Verify data-theme attribute is set
       const html = page.locator('html')
@@ -142,23 +165,19 @@ test.describe('Theme Visual Application', () => {
   test('each dark theme should have a unique background color', async ({
     page,
   }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for settings page to be fully rendered
-    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({
+    // Wait for sidebar to be fully rendered
+    await expect(page.locator('aside button:has-text("Theme")')).toBeVisible({
       timeout: 10000,
     })
 
     const backgrounds: Record<string, string> = {}
 
     for (const theme of THEMES.dark) {
-      // Select theme
-      const themeButton = page.locator('button').filter({
-        has: page.locator(`span:text-is("${theme.name}")`),
-      })
-      await expect(themeButton).toBeVisible()
-      await themeButton.click()
+      // Select theme via sidebar dropdown
+      await selectThemeFromSidebar(page, theme.name)
 
       // Wait for theme to be applied
       await expect(page.locator('html')).toHaveAttribute(
@@ -181,23 +200,19 @@ test.describe('Theme Visual Application', () => {
   test('each light theme should have a unique background color', async ({
     page,
   }) => {
-    await page.goto('/settings')
+    await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
-    // Wait for settings page to be fully rendered
-    await expect(page.getByRole('heading', { name: /settings/i })).toBeVisible({
+    // Wait for sidebar to be fully rendered
+    await expect(page.locator('aside button:has-text("Theme")')).toBeVisible({
       timeout: 10000,
     })
 
     const backgrounds: Record<string, string> = {}
 
     for (const theme of THEMES.light) {
-      // Select theme
-      const themeButton = page.locator('button').filter({
-        has: page.locator(`span:text-is("${theme.name}")`),
-      })
-      await expect(themeButton).toBeVisible()
-      await themeButton.click()
+      // Select theme via sidebar dropdown
+      await selectThemeFromSidebar(page, theme.name)
 
       // Wait for theme to be applied
       await expect(page.locator('html')).toHaveAttribute(

--- a/src/app/settings/SettingsClient.stories.tsx
+++ b/src/app/settings/SettingsClient.stories.tsx
@@ -2,8 +2,8 @@
  * SettingsClient Component Stories
  *
  * A client component for the Settings page.
- * Allows users to customize theme (14 themes: 7 light + 7 dark),
- * language (English/Japanese), and other display preferences.
+ * Manages display preferences (compact mode, card metadata).
+ * Theme selection is handled via the sidebar ThemeToggle.
  * Uses Redux for state management and localStorage for persistence.
  */
 

--- a/src/app/settings/SettingsClient.tsx
+++ b/src/app/settings/SettingsClient.tsx
@@ -1,12 +1,12 @@
 /**
  * Settings Client Component
  *
- * Manages theme, typography, and display settings
+ * Manages display settings (compact mode, card metadata).
+ * Theme selection is handled via the sidebar ThemeToggle.
  */
 
 'use client'
 
-import { Check, Sun, Moon, Monitor } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { memo, useMemo, useCallback } from 'react'
@@ -21,13 +21,7 @@ import {
   CardTitle,
 } from '@/components/ui/card'
 import { Label } from '@/components/ui/label'
-import { useTheme } from '@/hooks/use-theme'
-import {
-  type ThemeType,
-  LIGHT_THEMES,
-  DARK_THEMES,
-  THEME_INFO,
-} from '@/lib/constants/themes'
+import { useMounted } from '@/hooks/use-mounted'
 import {
   selectCompactMode,
   selectShowCardMetadata,
@@ -84,58 +78,10 @@ const Toggle = memo(function Toggle({
   )
 })
 
-/** Base styles for theme button */
-const THEME_BUTTON_BASE =
-  'relative flex flex-col items-center gap-2 rounded-lg border-2 p-4 transition-all'
-const THEME_BUTTON_SELECTED =
-  'border-primary bg-primary/5 ring-2 ring-primary ring-offset-2'
-const THEME_BUTTON_UNSELECTED =
-  'border-border hover:border-primary/50 hover:bg-muted/50'
-
-const ThemeButton = memo(function ThemeButton({
-  theme,
-  isSelected,
-  onClick,
-}: {
-  theme: ThemeType
-  isSelected: boolean
-  onClick: () => void
-}) {
-  const info = THEME_INFO[theme]
-
-  const buttonClassName = useMemo(
-    () =>
-      `${THEME_BUTTON_BASE} ${isSelected ? THEME_BUTTON_SELECTED : THEME_BUTTON_UNSELECTED}`,
-    [isSelected],
-  )
-
-  return (
-    <button type="button" onClick={onClick} className={buttonClassName}>
-      {theme === 'system' ? (
-        <div className="bg-muted flex h-10 w-10 items-center justify-center rounded-full">
-          <Monitor className="text-muted-foreground h-5 w-5" />
-        </div>
-      ) : (
-        <div
-          className={`h-10 w-10 rounded-full shadow-md ${info.needsBorder ? 'border border-gray-200' : ''}`}
-          style={{ backgroundColor: info.color }}
-        />
-      )}
-      <span className="text-sm font-medium">{info.name}</span>
-      <span className="text-muted-foreground text-xs">{info.description}</span>
-      {isSelected && (
-        <div className="bg-primary absolute -top-1 -right-1 flex h-5 w-5 items-center justify-center rounded-full">
-          <Check className="text-primary-foreground h-3 w-3" />
-        </div>
-      )}
-    </button>
-  )
-})
-
 export const SettingsClient = memo(function SettingsClient() {
   const router = useRouter()
   const dispatch = useAppDispatch()
-  const { theme, setTheme, mounted } = useTheme()
+  const mounted = useMounted()
 
   // Redux state for display settings
   const compactMode = useAppSelector(selectCompactMode)
@@ -196,69 +142,6 @@ export const SettingsClient = memo(function SettingsClient() {
       </div>
 
       <div className="space-y-6">
-        {/* Theme Selection */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Sun className="h-5 w-5" />
-              Theme
-            </CardTitle>
-            <CardDescription>
-              Choose a theme that matches your style. Light themes work best in
-              bright environments, dark themes reduce eye strain in low light.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {/* System Theme */}
-            <div>
-              <Label className="mb-3 block text-sm font-medium">System</Label>
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
-                <ThemeButton
-                  theme="system"
-                  isSelected={theme === 'system'}
-                  onClick={() => setTheme('system')}
-                />
-              </div>
-            </div>
-
-            {/* Light Themes */}
-            <div>
-              <Label className="mb-3 flex items-center gap-2 text-sm font-medium">
-                <Sun className="h-4 w-4" />
-                Light Themes
-              </Label>
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-                {LIGHT_THEMES.map((t) => (
-                  <ThemeButton
-                    key={t}
-                    theme={t}
-                    isSelected={theme === t}
-                    onClick={() => setTheme(t)}
-                  />
-                ))}
-              </div>
-            </div>
-
-            {/* Dark Themes */}
-            <div>
-              <Label className="mb-3 flex items-center gap-2 text-sm font-medium">
-                <Moon className="h-4 w-4" />
-                Dark Themes
-              </Label>
-              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
-                {DARK_THEMES.map((t) => (
-                  <ThemeButton
-                    key={t}
-                    theme={t}
-                    isSelected={theme === t}
-                    onClick={() => setTheme(t)}
-                  />
-                ))}
-              </div>
-            </div>
-          </CardContent>
-        </Card>
-
         {/* Display Settings */}
         <Card>
           <CardHeader>

--- a/src/app/settings/loading.tsx
+++ b/src/app/settings/loading.tsx
@@ -3,15 +3,8 @@ import { memo } from 'react'
 import { Skeleton } from '@/components/ui/skeleton'
 
 /**
- * Theme card skeleton matching the theme grid layout.
- */
-const ThemeCardSkeleton = memo(function ThemeCardSkeleton() {
-  return <Skeleton className="h-20 w-full rounded-lg" />
-})
-
-/**
  * Loading skeleton for settings page.
- * Matches layout: header, then theme grid.
+ * Matches layout: header, then display settings card with 2 toggle rows.
  */
 const Loading = memo(function Loading() {
   return (
@@ -22,16 +15,26 @@ const Loading = memo(function Loading() {
         <Skeleton className="mt-2 h-4 w-56" />
       </div>
 
-      {/* Theme section */}
-      <div className="mb-4">
-        <Skeleton className="h-5 w-20" />
-      </div>
-
-      {/* Theme grid */}
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-        {Array.from({ length: 14 }).map((_, i) => (
-          <ThemeCardSkeleton key={i} />
-        ))}
+      {/* Display Settings card */}
+      <div className="space-y-4 rounded-lg border p-6">
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="mt-1 h-4 w-64" />
+        {/* Toggle row 1 */}
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-4 w-28" />
+            <Skeleton className="mt-1 h-3 w-56" />
+          </div>
+          <Skeleton className="h-6 w-11 rounded-full" />
+        </div>
+        {/* Toggle row 2 */}
+        <div className="flex items-center justify-between">
+          <div>
+            <Skeleton className="h-4 w-36" />
+            <Skeleton className="mt-1 h-3 w-52" />
+          </div>
+          <Skeleton className="h-6 w-11 rounded-full" />
+        </div>
       </div>
     </div>
   )

--- a/src/components/CommandPalette/CommandPalette.tsx
+++ b/src/components/CommandPalette/CommandPalette.tsx
@@ -9,7 +9,6 @@ import {
   Archive,
   HelpCircle,
   LogOut,
-  Palette,
   Keyboard,
 } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -101,13 +100,6 @@ export const CommandPalette = memo(function CommandPalette() {
         icon: <PlusCircle className="h-4 w-4" />,
         shortcut: 'N',
         action: () => router.push('/boards/new'),
-        category: 'actions',
-      },
-      {
-        id: 'change-theme',
-        label: 'Change Theme',
-        icon: <Palette className="h-4 w-4" />,
-        action: () => router.push('/settings'),
         category: 'actions',
       },
       // Settings

--- a/src/tests/unit/components/CommandPalette/CommandPalette.test.tsx
+++ b/src/tests/unit/components/CommandPalette/CommandPalette.test.tsx
@@ -177,7 +177,6 @@ describe('CommandPalette', () => {
       openPalette()
 
       expect(screen.getByText('Create New Board')).toBeInTheDocument()
-      expect(screen.getByText('Change Theme')).toBeInTheDocument()
     })
 
     it('should display settings commands', () => {


### PR DESCRIPTION
## Summary

- Remove theme selection grid from Settings page (14 themes + System button) — duplicated sidebar ThemeToggle functionality
- Remove "Change Theme" command from CommandPalette
- Update Settings loading skeleton to match Display-only layout
- Rewrite theme E2E tests (persistence + visual application) to use sidebar ThemeToggle dropdown instead of Settings page
- Update `CLAUDE.md` to prefer `pnpm e2e:parallel` over `pnpm e2e`

Aligns Settings page with SPEC.md definition (Display-only, theme via Sidebar).

## Files Changed (9)

| File | Change |
|------|--------|
| `src/app/settings/SettingsClient.tsx` | Remove ThemeButton, theme Card, theme imports (-125 lines) |
| `src/app/settings/loading.tsx` | Replace theme grid skeleton with Display Settings skeleton |
| `src/app/settings/SettingsClient.stories.tsx` | Update JSDoc |
| `src/components/CommandPalette/CommandPalette.tsx` | Remove "Change Theme" command + Palette icon |
| `src/tests/unit/.../CommandPalette.test.tsx` | Remove "Change Theme" assertion |
| `e2e/logged-in/settings.spec.ts` | Replace theme tests with display settings tests |
| `e2e/logged-in/theme-persistence.spec.ts` | Rewrite: sidebar ThemeToggle dropdown |
| `e2e/logged-in/theme-visual-application.spec.ts` | Rewrite: sidebar ThemeToggle dropdown |
| `CLAUDE.md` | Prefer `pnpm e2e:parallel` for E2E |

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 warnings
- [x] `pnpm test` — 1282 unit tests pass
- [x] `pnpm build` — success
- [x] `pnpm e2e` — 276 pass, 0 fail
- [x] Browser verify: Settings shows Display-only (no theme grid)
- [x] Browser verify: Sidebar ThemeToggle dropdown works (all 14 themes)
- [x] Browser verify: Command Palette has no "Change Theme" entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display preferences toggles for compact mode and card metadata visibility in settings.

* **Bug Fixes/Changes**
  * Relocated theme selection from settings page to sidebar for improved accessibility.
  * Removed "Change Theme" from the command palette.

* **Tests**
  * Updated E2E tests to reflect new theme selection workflow and display settings verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->