### PR TITLE
fix(e2e): fix shard DB isolation and flaky test selectors

### DIFF
--- a/e2e/logged-in/note-modal.spec.ts
+++ b/e2e/logged-in/note-modal.spec.ts
@@ -50,7 +50,7 @@ test.describe('NoteModal (Authenticated)', () => {
     await expect(dialog).toBeVisible({ timeout: 5000 })
 
     // Dialog should have "Project Note" title
-    const title = dialog.getByText(/project note/i)
+    const title = dialog.getByRole('heading', { name: /project note/i })
     await expect(title).toBeVisible()
   })
 
@@ -83,9 +83,11 @@ test.describe('NoteModal (Authenticated)', () => {
     const dialog = page.getByRole('dialog')
     await expect(dialog).toBeVisible({ timeout: 5000 })
 
-    // Focus on editor and type
+    // Focus on editor, clear existing content, and type
     const editorContent = dialog.locator('[data-slate-editor="true"]')
     await editorContent.click()
+    await page.keyboard.press(`${MOD}+a`)
+    await page.keyboard.press('Backspace')
     await page.keyboard.type('Hello, this is a test note!')
 
     // Verify text was typed

--- a/e2e/logged-in/project-info-links.spec.ts
+++ b/e2e/logged-in/project-info-links.spec.ts
@@ -58,7 +58,7 @@ test.describe('ProjectInfo Links (Authenticated)', () => {
     const dialog = await openNoteModal(page)
 
     // Verify modal title (now "Project Note" after Issue #37 consolidation)
-    const title = dialog.getByText(/project note/i)
+    const title = dialog.getByRole('heading', { name: /project note/i })
     await expect(title).toBeVisible()
 
     // Verify modal has required elements

--- a/scripts/e2e-parallel.sh
+++ b/scripts/e2e-parallel.sh
@@ -117,6 +117,7 @@ for i in $(seq 0 $((SHARD_COUNT - 1))); do
   APP_ENV=test \
   NEXT_PUBLIC_ENABLE_MSW_MOCK=true \
   NEXT_PUBLIC_SUPABASE_URL="http://127.0.0.1:${postgrest_port}" \
+  SUPABASE_URL="http://127.0.0.1:${postgrest_port}" \
   NEXT_PUBLIC_SUPABASE_ANON_KEY="${LOCAL_SUPABASE_ANON_KEY}" \
   SUPABASE_SERVICE_ROLE_KEY="${LOCAL_SUPABASE_SERVICE_ROLE_KEY}" \
     pnpm exec next start -p "$port" > "/tmp/e2e-server-${port}.log" 2>&1 &

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -29,6 +29,11 @@ export const env = createEnv({
       .enum(['development', 'test', 'production'])
       .optional()
       .default('development'),
+    // Runtime-overridable Supabase URL for server-side code.
+    // NEXT_PUBLIC_SUPABASE_URL is inlined at build time by Next.js,
+    // so it cannot be changed per-process at runtime.
+    // E2E parallel shards use this to point each server to its own PostgREST.
+    SUPABASE_URL: z.string().min(1).optional(),
     // Service role key for admin operations (e.g., user deletion)
     // This bypasses RLS and should only be used for privileged operations
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
@@ -58,6 +63,7 @@ export const env = createEnv({
   runtimeEnv: {
     NODE_ENV: process.env.NODE_ENV,
     APP_ENV: process.env.APP_ENV,
+    SUPABASE_URL: process.env.SUPABASE_URL,
     SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY,
     NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
     NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -12,6 +12,18 @@ import { cookies } from 'next/headers'
 import type { Database } from './types'
 
 /**
+ * Get the Supabase URL, preferring runtime SUPABASE_URL over build-time NEXT_PUBLIC_SUPABASE_URL.
+ *
+ * NEXT_PUBLIC_* vars are inlined at build time by Next.js, so they can't be
+ * overridden per-process at runtime. For E2E parallel shards, each Next.js
+ * server needs its own PostgREST URL — SUPABASE_URL provides this.
+ *
+ * @returns Runtime SUPABASE_URL if set, otherwise build-time NEXT_PUBLIC_SUPABASE_URL
+ */
+const getSupabaseUrl = () =>
+  process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL!
+
+/**
  * Check if E2E test mode is enabled
  * When true, auth checks return mock data to bypass OAuth
  *
@@ -61,7 +73,7 @@ export async function createClient() {
   const testMode = isE2ETestMode()
 
   const supabase = createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
@@ -175,7 +187,7 @@ export async function createRouteHandlerClient(_request: Request) {
   const cookieStore = await cookies()
 
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
@@ -220,7 +232,7 @@ export async function createServerActionClient() {
   const cookieStore = await cookies()
 
   return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    getSupabaseUrl(),
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
@@ -282,12 +294,12 @@ const MOCK_USER_FOR_E2E = {
  * ```
  */
 export function createAdminClient() {
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseUrl = getSupabaseUrl()
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
   if (!supabaseUrl || !serviceRoleKey) {
     throw new Error(
-      'Missing SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_URL',
+      'Missing SUPABASE_SERVICE_ROLE_KEY or SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL',
     )
   }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `NEXT_PUBLIC_SUPABASE_URL` is inlined at build time by Next.js, so all 12 parallel E2E shards shared the same database (port 54321) instead of their shard-specific PostgREST instances — causing massive cross-test contamination (column renames, card deletes, board renames leaking across shards)
- **Fix**: Added runtime `SUPABASE_URL` server env var that `server.ts` prefers over the build-time `NEXT_PUBLIC_SUPABASE_URL`, restoring true per-shard database isolation
- **Also fixed**: `getByText(/project note/i)` strict mode violation (matched both dialog heading and editor content) and NoteModal typing test not clearing existing content

## Changes

| File | Change |
|------|--------|
| `src/lib/env.ts` | Added optional `SUPABASE_URL` server env var |
| `src/lib/supabase/server.ts` | Added `getSupabaseUrl()` helper; all 4 client creators use runtime URL |
| `scripts/e2e-parallel.sh` | Pass `SUPABASE_URL` to each Next.js server instance |
| `e2e/logged-in/note-modal.spec.ts` | `getByText` → `getByRole('heading')`; clear editor before typing |
| `e2e/logged-in/project-info-links.spec.ts` | `getByText` → `getByRole('heading')` |

## Test plan

- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm test` — 1282/1282 pass
- [x] `pnpm build` — pass
- [x] `pnpm e2e:parallel` — **12/12 shards pass** (was 3/12 before fix)