### PR TITLE
feat: add board preset templates for status list columns

### DIFF
--- a/e2e/logged-in/create-board.spec.ts
+++ b/e2e/logged-in/create-board.spec.ts
@@ -64,6 +64,44 @@ test.describe('Create Board Page (Authenticated)', () => {
     })
   })
 
+  test.describe('Preset Selection', () => {
+    test('should show Web App preset pre-selected', async ({ page }) => {
+      // Web App card should have selected styling (border-primary)
+      const webAppCard = page.getByRole('radio', { name: /web app/i })
+      await expect(webAppCard).toBeVisible({ timeout: 10000 })
+      await expect(webAppCard).toBeChecked()
+    })
+
+    test('should display all 6 preset cards', async ({ page }) => {
+      const presetLabels = [
+        'Software Release',
+        'Web App',
+        'Electron Desktop',
+        'CLI Tool',
+        'Mobile',
+        'macOS',
+      ]
+      for (const label of presetLabels) {
+        await expect(page.getByText(label, { exact: true })).toBeVisible()
+      }
+    })
+
+    test('should switch preset on click', async ({ page }) => {
+      // Click CLI Tool preset
+      const cliCard = page.getByRole('radio', { name: /cli tool/i })
+      await cliCard.click()
+      await expect(cliCard).toBeChecked()
+
+      // Verify CLI Tool column names are visible
+      await expect(page.getByText('Command', { exact: true })).toBeVisible()
+      await expect(page.getByText('Linter', { exact: true })).toBeVisible()
+
+      // Web App should no longer be checked
+      const webAppCard = page.getByRole('radio', { name: /web app/i })
+      await expect(webAppCard).not.toBeChecked()
+    })
+  })
+
   test.describe('Navigation', () => {
     test('should go back when Cancel is clicked', async ({ page }) => {
       // Navigate to boards first, then to create

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@radix-ui/react-popover':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1867,6 +1870,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7948,6 +7964,24 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:

--- a/src/app/boards/new/CreateBoardForm.stories.tsx
+++ b/src/app/boards/new/CreateBoardForm.stories.tsx
@@ -24,7 +24,7 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div className="bg-background w-150 rounded-lg border p-6">
+      <div className="bg-background w-200 rounded-lg border p-6">
         <Story />
       </div>
     ),

--- a/src/app/boards/new/CreateBoardForm.tsx
+++ b/src/app/boards/new/CreateBoardForm.tsx
@@ -1,8 +1,9 @@
 /**
  * Create Board Form Component
  *
- * Client Component for board creation
+ * Client Component for board creation.
  * - Name input with validation
+ * - Preset selector for status list column templates
  */
 
 'use client'
@@ -15,12 +16,16 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { createBoard } from '@/lib/actions/board'
+import { DEFAULT_PRESET_ID, type PresetId } from '@/lib/constants/board-presets'
 import { boardNameSchema } from '@/lib/validations/board'
+
+import { PresetSelector } from './PresetSelector'
 
 export const CreateBoardForm = memo(function CreateBoardForm() {
   const router = useRouter()
   const [isPending, startTransition] = useTransition()
   const [name, setName] = useState('')
+  const [presetId, setPresetId] = useState<PresetId>(DEFAULT_PRESET_ID)
   const [error, setError] = useState<string | null>(null)
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -37,7 +42,7 @@ export const CreateBoardForm = memo(function CreateBoardForm() {
     const validatedName = result.data
 
     startTransition(async () => {
-      const result = await createBoard(validatedName)
+      const result = await createBoard(validatedName, presetId)
       if (result.success) {
         toast.success('Board created', {
           description: `"${validatedName}" has been created.`,
@@ -69,6 +74,19 @@ export const CreateBoardForm = memo(function CreateBoardForm() {
         <p className="text-muted-foreground text-xs">
           {name.length}/50 characters
         </p>
+      </div>
+
+      {/* Preset Selection */}
+      <div className="space-y-2">
+        <Label>Column Preset</Label>
+        <p className="text-muted-foreground text-xs">
+          Choose how to organize your repos
+        </p>
+        <PresetSelector
+          value={presetId}
+          onChange={setPresetId}
+          disabled={isPending}
+        />
       </div>
 
       {/* Error Message */}

--- a/src/app/boards/new/PresetSelector.tsx
+++ b/src/app/boards/new/PresetSelector.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { memo } from 'react'
+
+import {
+  BOARD_PRESETS,
+  PRESET_IDS,
+  type PresetId,
+} from '@/lib/constants/board-presets'
+import { cn } from '@/lib/utils'
+
+interface PresetSelectorProps {
+  value: PresetId
+  onChange: (value: PresetId) => void
+  disabled?: boolean
+}
+
+/**
+ * Radio card grid for selecting a board preset.
+ * Shows 6 preset cards with color-coded column previews.
+ *
+ * @param value - Currently selected preset ID
+ * @param onChange - Callback when preset selection changes
+ * @param disabled - Disable all interactions (e.g., during form submission)
+ * @example
+ * <PresetSelector value="web-app" onChange={setPresetId} />
+ */
+export const PresetSelector = memo(function PresetSelector({
+  value,
+  onChange,
+  disabled,
+}: PresetSelectorProps) {
+  return (
+    <RadioGroupPrimitive.Root
+      value={value}
+      onValueChange={(v) => onChange(v as PresetId)}
+      disabled={disabled}
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+    >
+      {PRESET_IDS.map((presetId) => {
+        const preset = BOARD_PRESETS[presetId]
+        const isSelected = value === presetId
+        return (
+          <RadioGroupPrimitive.Item
+            key={presetId}
+            value={presetId}
+            className={cn(
+              'bg-card text-card-foreground rounded-lg border-2 p-4 text-left transition-colors',
+              'hover:border-primary/50 focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-none',
+              isSelected ? 'border-primary bg-primary/5' : 'border-border',
+              disabled && 'pointer-events-none opacity-50',
+            )}
+          >
+            <div className="text-sm font-medium">{preset.label}</div>
+            <div className="text-muted-foreground mt-0.5 text-xs">
+              {preset.description}
+            </div>
+            <div className="mt-2 space-y-1">
+              {preset.columns.map((col) => (
+                <div key={col.name} className="flex items-center gap-1.5">
+                  <span
+                    className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: col.color }}
+                  />
+                  <span className="text-muted-foreground text-xs">
+                    {col.name}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </RadioGroupPrimitive.Item>
+        )
+      })}
+    </RadioGroupPrimitive.Root>
+  )
+})

--- a/src/app/boards/new/page.tsx
+++ b/src/app/boards/new/page.tsx
@@ -33,12 +33,12 @@ export default async function NewBoardPage() {
   return (
     <div className="bg-background min-h-screen">
       <div className="container mx-auto px-4 py-16">
-        <div className="mx-auto max-w-lg">
+        <div className="mx-auto max-w-2xl">
           <h1 className="text-foreground text-center text-3xl font-bold">
             Create New Board
           </h1>
           <p className="text-muted-foreground mt-2 text-center">
-            Give your board a name and choose a theme
+            Give your board a name and choose a template
           </p>
 
           <div className="mt-8">

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import * as RadioGroupPrimitive from '@radix-ui/react-radio-group'
+import { Circle } from 'lucide-react'
+import {
+  memo,
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  type Ref,
+} from 'react'
+
+import { cn } from '@/lib/utils'
+
+const RadioGroup = memo(function RadioGroup({
+  className,
+  ref,
+  ...props
+}: ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root> & {
+  ref?: Ref<ComponentRef<typeof RadioGroupPrimitive.Root>>
+}) {
+  return (
+    <RadioGroupPrimitive.Root
+      ref={ref}
+      className={cn('grid gap-2', className)}
+      {...props}
+    />
+  )
+})
+
+const RadioGroupItem = memo(function RadioGroupItem({
+  className,
+  ref,
+  ...props
+}: ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item> & {
+  ref?: Ref<ComponentRef<typeof RadioGroupPrimitive.Item>>
+}) {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        'border-primary text-primary focus-visible:ring-ring aspect-square h-4 w-4 rounded-full border shadow focus:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="h-2.5 w-2.5 fill-current text-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+})
+
+export { RadioGroup, RadioGroupItem }

--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -14,6 +14,11 @@ import {
   withAuthResultRateLimit,
 } from '@/lib/actions/auth-guard'
 import { toRepoCardDomain, toStatusListDomain } from '@/lib/actions/mappers'
+import {
+  getPresetById,
+  DEFAULT_PRESET_ID,
+  type PresetId,
+} from '@/lib/constants/board-presets'
 import type { StatusListDomain, RepoCardDomain } from '@/lib/models/domain'
 import { createClient } from '@/lib/supabase/server'
 import type { TablesInsert } from '@/lib/supabase/types'
@@ -23,6 +28,7 @@ import {
   boardIdSchema,
   boardSettingsSchema,
   boardPositionUpdatesSchema,
+  presetIdSchema,
   statusListNameSchema,
   statusListColorSchema,
   gridPositionSchema,
@@ -62,71 +68,64 @@ export async function getStatusLists(
 }
 
 /**
- * Create default status lists for a new board
- * Called when a board has no status lists
- * All columns start in row 0 (single row layout)
+ * Create status lists from a preset definition.
+ * Maps preset columns to database rows with grid positioning.
+ *
+ * @param boardId - Target board UUID
+ * @param presetId - Preset identifier from PRESET_IDS
+ * @returns Created StatusListDomain array
+ * @example
+ * await createStatusListsFromPreset(boardId, 'web-app')
+ * // Creates: Frontend, Backend, Fullstack, Library, Infrastructure
  */
-export async function createDefaultStatusLists(
+async function createStatusListsFromPreset(
   boardId: string,
+  presetId: PresetId,
 ): Promise<StatusListDomain[]> {
   const supabase = await createClient()
+  const preset = getPresetById(presetId)
 
-  const defaultLists: TablesInsert<'statuslist'>[] = [
-    {
+  const statusLists: TablesInsert<'statuslist'>[] = preset.columns.map(
+    (col, index) => ({
       board_id: boardId,
-      name: 'Pending',
-      color: '#8B7355',
-      order: 0,
+      name: col.name,
+      color: col.color,
+      order: index,
       grid_row: 0,
-      grid_col: 0,
-    },
-    {
-      board_id: boardId,
-      name: 'Planning',
-      color: '#6B8E23',
-      order: 1,
-      grid_row: 0,
-      grid_col: 1,
-    },
-    {
-      board_id: boardId,
-      name: 'Focus Development',
-      color: '#CD853F',
-      order: 2,
-      grid_row: 0,
-      grid_col: 2,
-    },
-    {
-      board_id: boardId,
-      name: 'MVP Release',
-      color: '#4682B4',
-      order: 3,
-      grid_row: 0,
-      grid_col: 3,
-    },
-    {
-      board_id: boardId,
-      name: 'Production Release',
-      color: '#556B2F',
-      order: 4,
-      grid_row: 0,
-      grid_col: 4,
-    },
-  ]
+      grid_col: index,
+    }),
+  )
 
   const { data, error } = await supabase
     .from('statuslist')
-    .insert(defaultLists)
+    .insert(statusLists)
     .select()
 
   if (error) {
     Sentry.captureException(error, {
-      extra: { context: 'Create default status lists', boardId },
+      extra: { context: 'Create status lists from preset', boardId, presetId },
     })
-    throw new Error('Failed to create default status lists')
+    throw new Error('Failed to create status lists')
   }
 
   return (data || []).map(toStatusListDomain)
+}
+
+/**
+ * Create default status lists for a new board.
+ * Delegates to the Software Release preset.
+ * Called by getBoardData (fallback) and createFirstBoardIfNeeded.
+ *
+ * @param boardId - Target board UUID
+ * @returns Created StatusListDomain array
+ * @example
+ * await createDefaultStatusLists(boardId)
+ * // Creates: Pending, Planning, Focus Development, MVP Release, Production Release
+ */
+export async function createDefaultStatusLists(
+  boardId: string,
+): Promise<StatusListDomain[]> {
+  return createStatusListsFromPreset(boardId, 'software-release')
 }
 
 /**
@@ -473,16 +472,34 @@ export async function getBoardData(boardId: string): Promise<{
  *   router.push(`/board/${result.data.id}`)
  * }
  */
+/**
+ * Create a new board with status lists from a preset.
+ *
+ * @param name - Board display name (1-50 chars)
+ * @param presetId - Status list preset to apply (defaults to 'web-app')
+ * @returns ActionResult with created board id and name
+ * @example
+ * await createBoard('Side Projects', 'cli-tool')
+ * // => { success: true, data: { id: 'uuid', name: 'Side Projects' } }
+ */
 export async function createBoard(
   name: string,
+  presetId?: string,
 ): Promise<ActionResult<{ id: string; name: string }>> {
   // Validate board name (P2-3)
-  const validation = boardNameSchema.safeParse(name)
-  if (!validation.success) {
+  const nameValidation = boardNameSchema.safeParse(name)
+  if (!nameValidation.success) {
     return {
       success: false,
-      error: validation.error.issues[0]?.message || 'Invalid board name',
+      error: nameValidation.error.issues[0]?.message || 'Invalid board name',
     }
+  }
+
+  // Validate preset ID (default to 'web-app' if omitted)
+  const resolvedPresetId = presetId ?? DEFAULT_PRESET_ID
+  const presetValidation = presetIdSchema.safeParse(resolvedPresetId)
+  if (!presetValidation.success) {
+    return { success: false, error: 'Invalid preset selection' }
   }
 
   return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
@@ -511,8 +528,8 @@ export async function createBoard(
       throw new Error('Failed to create board')
     }
 
-    // Create default status lists for the new board
-    await createDefaultStatusLists(data.id)
+    // Create status lists from selected preset
+    await createStatusListsFromPreset(data.id, presetValidation.data)
 
     return { id: data.id, name: data.name }
   })

--- a/src/lib/constants/board-presets.ts
+++ b/src/lib/constants/board-presets.ts
@@ -1,0 +1,137 @@
+/**
+ * Board Preset Definitions
+ *
+ * Status List preset patterns for board creation.
+ * Shared between client (CreateBoardForm) and server (board.ts actions).
+ *
+ * @example
+ * import { BOARD_PRESETS, DEFAULT_PRESET_ID, getPresetById } from '@/lib/constants/board-presets'
+ *
+ * // Get the default preset
+ * const preset = BOARD_PRESETS[DEFAULT_PRESET_ID]
+ * // => { id: 'web-app', label: 'Web App', columns: [...] }
+ *
+ * // Get a preset by ID with fallback
+ * const preset = getPresetById('cli-tool')
+ * // => { id: 'cli-tool', label: 'CLI Tool', columns: [...] }
+ */
+
+/** Single column definition within a preset */
+export interface PresetColumn {
+  /** Column display name */
+  name: string
+  /** Column header color (hex) */
+  color: string
+}
+
+/** Board preset definition */
+export interface BoardPreset {
+  /** Unique identifier (kebab-case) */
+  id: string
+  /** Display name shown on the radio card */
+  label: string
+  /** Short description for context */
+  description: string
+  /** Columns this preset creates */
+  columns: readonly PresetColumn[]
+}
+
+export const PRESET_IDS = [
+  'software-release',
+  'web-app',
+  'electron-desktop',
+  'cli-tool',
+  'mobile',
+  'macos',
+] as const
+
+export type PresetId = (typeof PRESET_IDS)[number]
+
+export const DEFAULT_PRESET_ID: PresetId = 'web-app'
+
+export const BOARD_PRESETS: Record<PresetId, BoardPreset> = {
+  'software-release': {
+    id: 'software-release',
+    label: 'Software Release',
+    description: 'Track repos through release lifecycle',
+    columns: [
+      { name: 'Pending', color: '#8B7355' },
+      { name: 'Planning', color: '#6B8E23' },
+      { name: 'Focus Development', color: '#CD853F' },
+      { name: 'MVP Release', color: '#4682B4' },
+      { name: 'Production Release', color: '#556B2F' },
+    ],
+  },
+  'web-app': {
+    id: 'web-app',
+    label: 'Web App',
+    description: 'Categorize web application repos',
+    columns: [
+      { name: 'Frontend', color: '#3B82F6' },
+      { name: 'Backend', color: '#10B981' },
+      { name: 'Fullstack', color: '#8B5CF6' },
+      { name: 'Library', color: '#F59E0B' },
+      { name: 'Infrastructure', color: '#6366F1' },
+    ],
+  },
+  'electron-desktop': {
+    id: 'electron-desktop',
+    label: 'Electron Desktop',
+    description: 'Organize Electron ecosystem repos',
+    columns: [
+      { name: 'Main App', color: '#2563EB' },
+      { name: 'Plugin', color: '#7C3AED' },
+      { name: 'Theme', color: '#EC4899' },
+      { name: 'Utility', color: '#14B8A6' },
+      { name: 'Build Tool', color: '#F97316' },
+    ],
+  },
+  'cli-tool': {
+    id: 'cli-tool',
+    label: 'CLI Tool',
+    description: 'Manage command-line tool repos',
+    columns: [
+      { name: 'Command', color: '#059669' },
+      { name: 'Framework', color: '#4F46E5' },
+      { name: 'Generator', color: '#D97706' },
+      { name: 'Linter', color: '#DC2626' },
+      { name: 'Config', color: '#6B7280' },
+    ],
+  },
+  mobile: {
+    id: 'mobile',
+    label: 'Mobile',
+    description: 'iOS, Android, and cross-platform repos',
+    columns: [
+      { name: 'iOS', color: '#3B82F6' },
+      { name: 'Android', color: '#22C55E' },
+      { name: 'Cross-Platform', color: '#A855F7' },
+      { name: 'Backend', color: '#EF4444' },
+      { name: 'Library', color: '#F59E0B' },
+    ],
+  },
+  macos: {
+    id: 'macos',
+    label: 'macOS',
+    description: 'macOS native application repos',
+    columns: [
+      { name: 'Native App', color: '#0EA5E9' },
+      { name: 'Menu Bar', color: '#8B5CF6' },
+      { name: 'Widget', color: '#F43F5E' },
+      { name: 'Utility', color: '#14B8A6' },
+      { name: 'System Extension', color: '#64748B' },
+    ],
+  },
+} as const
+
+/**
+ * Get preset by ID with fallback to default.
+ * @param id - Preset identifier string
+ * @returns Matching BoardPreset, or default (web-app) if not found
+ * @example
+ * getPresetById('cli-tool')  // => { id: 'cli-tool', label: 'CLI Tool', ... }
+ * getPresetById('unknown')   // => { id: 'web-app', label: 'Web App', ... }
+ */
+export function getPresetById(id: string): BoardPreset {
+  return BOARD_PRESETS[id as PresetId] ?? BOARD_PRESETS[DEFAULT_PRESET_ID]
+}

--- a/src/lib/validations/board.ts
+++ b/src/lib/validations/board.ts
@@ -6,6 +6,8 @@
 
 import { z } from 'zod'
 
+import { PRESET_IDS } from '@/lib/constants/board-presets'
+
 import { uuidSchema } from './common'
 
 // ========================================
@@ -31,6 +33,19 @@ export const boardNameSchema = z
     BOARD_NAME_MAX_LENGTH,
     `Board name must be ${BOARD_NAME_MAX_LENGTH} characters or less`,
   )
+
+// ========================================
+// Board Preset ID Schema
+// ========================================
+
+/**
+ * Schema for validating board preset IDs.
+ *
+ * @example
+ * presetIdSchema.safeParse('web-app')    // => { success: true, data: 'web-app' }
+ * presetIdSchema.safeParse('unknown')    // => { success: false, error: ... }
+ */
+export const presetIdSchema = z.enum(PRESET_IDS)
 
 // ========================================
 // Board Subtitle Schema


### PR DESCRIPTION
## Summary

- Add 6 board preset templates (Software Release, Web App, Electron Desktop, CLI Tool, Mobile, macOS) for selecting column layouts when creating a new board
- Radio card grid UI with color-coded column previews on `/boards/new`
- Web App preset selected by default; existing boards and `createFirstBoardIfNeeded` unaffected (still uses Software Release columns)

## Changes

### New Files
- `src/lib/constants/board-presets.ts` — Preset definitions (shared by client + server)
- `src/components/ui/radio-group.tsx` — shadcn/ui RadioGroup primitive
- `src/app/boards/new/PresetSelector.tsx` — Radio card grid component

### Modified Files
- `src/lib/validations/board.ts` — Added `presetIdSchema` Zod enum
- `src/lib/actions/board.ts` — Added `createStatusListsFromPreset()`, updated `createBoard(name, presetId?)` signature
- `src/app/boards/new/CreateBoardForm.tsx` — Preset state + PresetSelector integration
- `src/app/boards/new/page.tsx` — Wider container, updated subtitle
- `src/app/boards/new/CreateBoardForm.stories.tsx` — Wider decorator
- `e2e/logged-in/create-board.spec.ts` — 3 new preset selection tests

## Test plan

- [x] TypeScript typecheck passes
- [x] ESLint passes (0 warnings)
- [x] Unit/Storybook tests pass (91 suites, 1290 tests)
- [x] Build passes
- [x] E2E create-board tests pass (11/11 including 3 new preset tests)
- [ ] Manual: `/boards/new` shows Web App preset pre-selected
- [ ] Manual: Click each preset — column preview updates correctly
- [ ] Manual: Create board with different presets — correct columns created
- [ ] Manual: Keyboard nav (Tab + arrow keys) between presets
- [ ] Manual: Dark theme rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added board template selection during board creation. Users can now choose from multiple preset templates, each with pre-configured columns and colors.

* **Tests**
  * Added comprehensive test coverage for template selection and preset validation.

* **Chores**
  * Updated dependencies to support new template selection UI component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->