### PR TITLE
fix(board): isolate OverflowMenu events from dnd-kit drag listeners

### DIFF
--- a/src/components/Board/OverflowMenu.tsx
+++ b/src/components/Board/OverflowMenu.tsx
@@ -108,8 +108,46 @@ function OverflowMenuInner<TId extends CardIdentifier>({
     setShowDeleteDialog(false)
   }
 
+  /**
+   * Stop propagation of pointer / mouse / click / keyboard events so they
+   * never reach a draggable ancestor (e.g. a `useSortable` wrapper on
+   * `RepoCard`).
+   *
+   * Why this is needed:
+   * - Radix UI renders `DropdownMenuContent` and `AlertDialogContent` inside
+   *   a Portal, but React replays synthetic events through the React tree —
+   *   not the DOM tree.
+   * - When a menu item is clicked, the synthetic event bubbles back up
+   *   through `OverflowMenu` to whatever ancestor mounted it.
+   * - If that ancestor has `dnd-kit` listeners (`{...listeners}` spread on
+   *   the wrapper), `MouseSensor` records the pointerdown and may trigger a
+   *   drag if the cursor moves more than `activationConstraint.distance`
+   *   between pointerdown and pointerup. Once a drag starts, dnd-kit
+   *   suppresses the trailing `click`, so the menu item's `onClick` never
+   *   fires.
+   * - Stopping propagation here lets Radix's own handlers run first (they
+   *   are deeper in the React tree) and then short-circuits bubbling so the
+   *   draggable parent never sees the event.
+   *
+   * @example
+   * // Without this guard, "Move to Maintenance" silently does nothing on
+   * // production: the menu closes, the action never executes.
+   */
+  const stopPointerBubble = (
+    event: React.PointerEvent | React.MouseEvent | React.KeyboardEvent,
+  ) => {
+    event.stopPropagation()
+  }
+
   return (
-    <>
+    <div
+      className="contents"
+      onPointerDown={stopPointerBubble}
+      onMouseDown={stopPointerBubble}
+      onClick={stopPointerBubble}
+      onKeyDown={stopPointerBubble}
+      data-testid={`overflow-menu-isolation-${cardId}`}
+    >
       <DropdownMenu open={open} onOpenChange={onOpenChange}>
         <DropdownMenuTrigger
           className="hover:bg-accent hover:text-accent-foreground focus:ring-ring rounded-md p-1 focus:ring-2 focus:ring-offset-2 focus:outline-none"
@@ -265,7 +303,7 @@ function OverflowMenuInner<TId extends CardIdentifier>({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </>
+    </div>
   )
 }
 

--- a/src/components/Board/RepoCard.tsx
+++ b/src/components/Board/RepoCard.tsx
@@ -171,9 +171,19 @@ export const RepoCard = memo<RepoCardProps>(
      * Keyboard navigation handler
      * Requirements: Full keyboard navigation support
      *
+     * Defensive guard: only react to keys that originated on the Card itself.
+     * Without this, keystrokes from descendants rendered via Portal (e.g. the
+     * `OverflowMenu` `DropdownMenuItem`s) would bubble through the React tree
+     * and accidentally open the Note modal when the user pressed Enter on a
+     * focused menu item.
+     *
      * @param e - KeyboardEvent
      */
     const handleKeyDown = (e: React.KeyboardEvent) => {
+      // Ignore events forwarded from a portal child (menu item, dialog, etc.)
+      // so the card's shortcuts never fire while a child has focus.
+      if (e.target !== e.currentTarget) return
+
       // Enter: Open NoteModal (unified notes + links)
       if (e.key === 'Enter' && onNote) {
         e.preventDefault()

--- a/src/tests/unit/components/Board/OverflowMenu.test.tsx
+++ b/src/tests/unit/components/Board/OverflowMenu.test.tsx
@@ -429,4 +429,116 @@ describe('OverflowMenu', () => {
       expect(separators.length).toBeGreaterThan(0)
     })
   })
+
+  /**
+   * Regression coverage for the dnd-kit + Radix Portal interaction bug.
+   *
+   * Background:
+   * - `RepoCard` spreads `useSortable` `attributes` and `listeners` on its
+   *   wrapper div, making the entire card a drag handle.
+   * - Radix renders menu items inside a Portal. React still bubbles synthetic
+   *   events from those portal children up through the React tree, so without
+   *   isolation `pointerdown` from a menu item would reach `MouseSensor`.
+   *   `MouseSensor` would then start a drag on small cursor jitter and
+   *   suppress the trailing `click`, leaving the menu item's `onClick`
+   *   silently unfired.
+   *
+   * `OverflowMenu` mounts a `display: contents` wrapper that stops bubbling
+   * for pointer / mouse / click / key events. These tests pin that contract.
+   */
+  describe('Event Propagation Isolation (dnd-kit guard)', () => {
+    it('should render an isolation wrapper that catches bubbling events', () => {
+      render(
+        <OverflowMenu
+          {...defaultProps}
+          open={true}
+          context="board"
+          onMoveToMaintenance={mockOnMoveToMaintenance}
+        />,
+      )
+
+      const isolation = screen.getByTestId('overflow-menu-isolation-card-1')
+      expect(isolation).toBeInTheDocument()
+      expect(isolation).toHaveClass('contents')
+    })
+
+    it('should stop click bubbling from menu items reaching draggable ancestor', async () => {
+      const ancestorClickSpy = vi.fn()
+      const ancestorPointerDownSpy = vi.fn()
+      const ancestorMouseDownSpy = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        // Simulates the draggable wrapper that `useSortable` injects on
+        // `RepoCard`. If isolation regresses, these spies will fire.
+        <div
+          data-testid="draggable-ancestor"
+          onClick={ancestorClickSpy}
+          onPointerDown={ancestorPointerDownSpy}
+          onMouseDown={ancestorMouseDownSpy}
+        >
+          <OverflowMenu
+            {...defaultProps}
+            open={true}
+            context="board"
+            onMoveToMaintenance={mockOnMoveToMaintenance}
+          />
+        </div>,
+      )
+
+      await user.click(screen.getByTestId('move-to-maintenance-card-1'))
+
+      expect(mockOnMoveToMaintenance).toHaveBeenCalledWith('card-1')
+      expect(ancestorClickSpy).not.toHaveBeenCalled()
+      expect(ancestorPointerDownSpy).not.toHaveBeenCalled()
+      expect(ancestorMouseDownSpy).not.toHaveBeenCalled()
+    })
+
+    it('should stop click bubbling when opening menu via the trigger', async () => {
+      const ancestorClickSpy = vi.fn()
+      const ancestorPointerDownSpy = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <div
+          data-testid="draggable-ancestor"
+          onClick={ancestorClickSpy}
+          onPointerDown={ancestorPointerDownSpy}
+        >
+          <OverflowMenu
+            {...defaultProps}
+            context="board"
+            onMoveToMaintenance={mockOnMoveToMaintenance}
+          />
+        </div>,
+      )
+
+      await user.click(screen.getByTestId('overflow-menu-trigger-card-1'))
+
+      expect(mockOnOpenChange).toHaveBeenCalledWith(true)
+      expect(ancestorClickSpy).not.toHaveBeenCalled()
+      expect(ancestorPointerDownSpy).not.toHaveBeenCalled()
+    })
+
+    it('should stop keyboard events bubbling from the menu trigger', async () => {
+      const ancestorKeyDownSpy = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <div data-testid="draggable-ancestor" onKeyDown={ancestorKeyDownSpy}>
+          <OverflowMenu
+            {...defaultProps}
+            context="board"
+            onMoveToMaintenance={mockOnMoveToMaintenance}
+          />
+        </div>,
+      )
+
+      const trigger = screen.getByTestId('overflow-menu-trigger-card-1')
+      trigger.focus()
+      await user.keyboard('{Enter}')
+
+      expect(ancestorKeyDownSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/tests/unit/components/Board/RepoCard.test.tsx
+++ b/src/tests/unit/components/Board/RepoCard.test.tsx
@@ -328,6 +328,32 @@ describe('RepoCard', () => {
         'closed',
       )
     })
+
+    /**
+     * Regression: previously the Card swallowed every Enter key bubbling up
+     * through the React tree, including ones forwarded from descendants such
+     * as the OverflowMenu's portal-rendered DropdownMenuItem. Pressing Enter
+     * on "Move to Maintenance" therefore opened the Note modal instead of
+     * triggering the menu action.
+     *
+     * The handler now ignores events whose target differs from the Card
+     * itself. This test pins the new contract so the bug cannot quietly
+     * return.
+     */
+    it('should ignore Enter events that bubbled up from a descendant', () => {
+      render(<RepoCard card={defaultCard} onNote={mockOnNote} />)
+
+      const cardContent = screen
+        .getByTestId('repo-card-card-1')
+        .querySelector('[tabIndex="0"]')!
+
+      // Simulate Enter coming from a descendant (e.g. a Radix menu item):
+      // the event's target is a child node, but the handler runs on the Card.
+      const innerChild = cardContent.querySelector('[data-testid="repo-name"]')!
+      fireEvent.keyDown(innerChild, { key: 'Enter', bubbles: true })
+
+      expect(mockOnNote).not.toHaveBeenCalled()
+    })
   })
 
   describe('Callback Invocations', () => {


### PR DESCRIPTION
## Summary

- 🐛 **Production bug**: clicking *Move to Maintenance* / *Move to Another Board* / *Remove from Board* in a card's overflow menu silently no-ops or opens the unrelated Note modal instead of triggering the action.
- 🔬 **Root cause**: `RepoCard` spreads `useSortable` `attributes` and `listeners` on its wrapper div, so the entire card is a drag handle. Radix renders `DropdownMenuContent` inside a Portal, but React still bubbles synthetic events from portal children up through the React tree. A `pointerdown` on a menu item therefore reached `MouseSensor` on the wrapper. With `activationConstraint.distance: 8`, even small cursor jitter between `pointerdown` and `pointerup` started a drag, and dnd-kit then suppressed the trailing `click` — so the menu item's `onClick` never fired.
- ✅ **Fix**:
  - `OverflowMenu` now mounts a `display: contents` wrapper that stops propagation for `pointerdown` / `mousedown` / `click` / `keydown`. Radix's own handlers still run first because they live deeper in the React tree, but the draggable ancestor never sees menu events.
  - `RepoCard.handleKeyDown` early-returns when `e.target !== e.currentTarget`, so portal-forwarded keystrokes (e.g. `Enter` on a focused menu item) can no longer accidentally open the Note modal.

## Why this design

- **Isolation belongs to the menu, not its host.** Any future component that reuses `OverflowMenu` inside a drag context gets the fix for free.
- **`display: contents` keeps the existing flex layout untouched** — no visual diff, no extra spacing.
- **Radix-friendly**: stopping propagation *above* Radix preserves all its internal pointer/keyboard handling. The trigger still opens the menu, items still fire `onSelect`, the Cancel/Confirm dialog still works.
- **Defense in depth** on `RepoCard`: even if a future ancestor forgets to isolate, the card's own shortcuts won't misfire on bubbled events.

## Test plan

- [x] `pnpm vitest run src/tests/unit/components/Board/` — **194/194 pass** (5 new tests pinning the new contract):
  - `OverflowMenu` › *Event Propagation Isolation (dnd-kit guard)* (4 tests):
    - Renders the `display: contents` isolation wrapper
    - Click on `Move to Maintenance` does **not** bubble `click`/`pointerdown`/`mousedown` to a draggable ancestor
    - Click on the trigger does **not** bubble to the ancestor
    - Keyboard events on the trigger do **not** bubble to the ancestor
  - `RepoCard` › *Keyboard Navigation* (1 test): `Enter` bubbled from a descendant is ignored (no `onNote` fired)
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` on changed files — clean
- [ ] Manual verification on production after deploy: open a Stable board card menu → *Move to Maintenance* → card disappears + toast shows "Moved to maintenance"

## Files changed

| File | Change |
|---|---|
| `src/components/Board/OverflowMenu.tsx` | Add `display: contents` isolation wrapper |
| `src/components/Board/RepoCard.tsx` | Defensive `e.target !== e.currentTarget` guard in `handleKeyDown` |
| `src/tests/unit/components/Board/OverflowMenu.test.tsx` | +4 regression tests |
| `src/tests/unit/components/Board/RepoCard.test.tsx` | +1 regression test |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved menu dropdown interactions being interrupted when used on draggable items.
  * Improved keyboard event handling to prevent shortcuts from triggering unexpectedly in nested interactive elements.

* **Tests**
  * Added regression tests for menu operation isolation in draggable contexts.
  * Added tests verifying proper keyboard event behavior in card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->