### PR TITLE
feat(auth): silent GitHub OAuth token refresh on expired provider token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0] - 2026-04-29
+
+### Added
+
+- Silent GitHub OAuth token refresh on expired provider token. When a Server Action returns `errorCode: 'GITHUB_TOKEN_MISSING'`, the client redirects to `/api/auth/github/refresh?next=<path>`, which silently re-runs OAuth via Supabase and returns the user to the original page.
+- `sanitizeNextPath` utility for open-redirect-safe `next` query parameter handling. Reused by `/auth/callback` and `/api/auth/github/refresh`.
+- `getForwardedClientIp` utility consolidating `x-forwarded-for` parsing for rate-limit IP resolution.
+- `handleGitHubTokenMissing` client helper with module-level lock and `sessionStorage` attempt counter for loop protection.
+- `errorCode: 'GITHUB_TOKEN_MISSING'` discriminant on `ActionResult<T>` failure variant; emitted by 4 GitHub Server Actions.
+- Unit tests for the refresh route, both new hooks, the client helper, the cookie module, the 401 interceptor, and `errorCode` propagation across GitHub Server Actions.
+- E2E spec covering the refresh route's attempt-cap bail-out (`e2e/logged-in/silent-token-refresh.spec.ts`).
+- gstack skill-routing rules in `CLAUDE.md`.
+
+### Changed
+
+- GitHub provider token cookie TTL extended from 8 hours to 30 days, aligned with the Supabase refresh token lifetime. Cookie remains `httpOnly`, `secure` (production), and `SameSite=Lax`.
+- `signOut`, `deleteAccount`, and the axios 401 interceptor now use the shared `deleteGitHubTokenCookie` helper.
+- `auth.ts`, `github.ts`, `public-board.ts`, and the refresh route now use the shared `getForwardedClientIp` helper for consistent x-forwarded-for parsing.
+
+### Fixed
+
+- Bookmark-after-8-hours bug: users returning to a bookmarked `/board/<id>` after the previous 8-hour cookie window no longer hit "GitHub token not found. Please sign in again." The flow now silently re-authenticates and lands them back on the original page.
+
+## [0.2.0] - prior
+
+Initial tracked release.
+
+[Unreleased]: https://github.com/laststance/gitbox/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/laststance/gitbox/compare/v0.2.0...v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -472,3 +472,22 @@ Key project-specific rules:
 > Raphtalia: ミーティング終わった。ちょっと疲れたけど3時間くらいは休めば体力回復するかな。
 >
 > Claude: お疲れさまです。しっかり休んでからの方がいい判断もいいコードも書けるので、無理せず回復してからまた取り掛かりましょう。coreliveのoptimistic update実装か、git-gpt-commitの最新バージョン対応か、準備ができたら声かけてください。
+
+## Skill routing
+
+When the user's request matches an available skill, invoke it via the Skill tool. When in doubt, invoke the skill.
+
+Key routing rules:
+
+- Product ideas/brainstorming → invoke /office-hours
+- Strategy/scope → invoke /plan-ceo-review
+- Architecture → invoke /plan-eng-review
+- Design system/plan review → invoke /design-consultation or /plan-design-review
+- Full review pipeline → invoke /autoplan
+- Bugs/errors → invoke /investigate
+- QA/testing site behavior → invoke /qa or /qa-only
+- Code review/diff check → invoke /review
+- Visual polish → invoke /design-review
+- Ship/deploy/PR → invoke /ship or /land-and-deploy
+- Save progress → invoke /context-save
+- Resume context → invoke /context-restore

--- a/TODOS.md
+++ b/TODOS.md
@@ -4,7 +4,7 @@ Follow-up items surfaced during code review. Not ship-blockers — captured here
 
 ## Silent GitHub Token Refresh — P2 follow-ups
 
-From the `/ship` adversarial review of `feat/silent-github-token-refresh` (PR #TBD).
+From the `/ship` adversarial review of `feat/silent-github-token-refresh` (PR #176).
 
 ### UX
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,33 @@
+# TODOs
+
+Follow-up items surfaced during code review. Not ship-blockers — captured here so they don't get lost.
+
+## Silent GitHub Token Refresh — P2 follow-ups
+
+From the `/ship` adversarial review of `feat/silent-github-token-refresh` (PR #TBD).
+
+### UX
+
+- [ ] **Preserve `?query` and `#hash` on silent refresh redirect.** `useOrganizationData.ts:65` and `useRepositoryData.ts:62` (and any other call site) pass `window.location.pathname` only; users on `/board/abc?filter=open#card-123` land on `/board/abc` after refresh. Pass `${pathname}${search}${hash}` instead. `sanitizeNextPath` already accepts the full string.
+- [ ] **Clear refresh attempt counter on `/login?error=token_refresh_failed`.** When the route bails on `attempt > MAX_REFRESH_ATTEMPTS`, sessionStorage still reads `2`; the next visit bails immediately even though it's a new session. Either clear in `/login` mount when that error is present, or have the route emit a clearing `Set-Cookie` signal.
+
+### Concurrency / correctness
+
+- [ ] **Multi-tab PKCE collision.** Tab A mid-refresh + Tab B clicking "Sign in with GitHub" can clobber the Supabase `sb-…-code-verifier` cookie, causing "invalid grant" on the slower tab's `/auth/callback`. Detect "code verifier mismatch" specifically in callback and treat as recoverable (silent restart) rather than surfacing the raw error.
+- [ ] **401 interceptor races freshly-set cookie.** `axios-github.ts:101-110` unconditionally calls `deleteGitHubTokenCookie()` on any 401. A stale request resolving after refresh completes can nuke the fresh cookie. Gate deletion on the in-flight token matching the current cookie value.
+- [ ] **Race on rapid combobox open/close.** `useOrganizationData` and `useRepositoryData` lack `AbortController` and a `cancelled` flag. Out-of-order resolution from rapid open→close→open can land stale data. Add an `ignore` flag in the effect closure.
+
+### Security / rate-limit
+
+- [ ] **`x-forwarded-for` first-IP spoofing on Vercel.** `getForwardedClientIp` takes `split(',')[0]`, which on Vercel can be attacker-controlled (Vercel appends rather than replaces). Bypass is rate-limit-only and requires authenticated session. Switch to `x-real-ip` (Vercel-set) or read the LAST entry of x-forwarded-for.
+- [ ] **Server-side `attempt` cap bypassed when `sessionStorage` unavailable.** If Safari private mode / quota exceeded, the client always sends `attempt=1`; the server cap (`> 1`) never trips. Add a server-side short-lived nonce/cookie counter, or send `attempt=2` after first in-memory attempt when storage fails.
+- [ ] **Error message reflection in `/login?message=...`.** `route.ts:80,124` reflect `rateLimitResult.error` and `oauthError.message` via `encodeURIComponent` to a redirect URL. Emit fixed error codes only (`rate_limited`, `oauth_failed`); keep messages in server logs / Sentry.
+
+### Tests
+
+- [ ] **Dedicated unit tests for `sanitizeNextPath`** (especially the `null`-input branch — currently exercised only indirectly via the refresh-route tests).
+- [ ] **Dedicated unit tests for `getForwardedClientIp`** — multi-hop chain, whitespace, empty header, malformed input.
+
+### Risk acceptance
+
+- [ ] **30-day provider token cookie TTL — risk re-confirm.** Materially expands replay window vs. previous 8h. Cookie flags are good (`httpOnly`, `secure` in prod, `SameSite=Lax`); scope is `read:user user:email repo` (write access included). If write access isn't required for current product surface, narrow the OAuth scopes.

--- a/e2e/logged-in/silent-token-refresh.spec.ts
+++ b/e2e/logged-in/silent-token-refresh.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Silent GitHub Token Refresh E2E Tests
+ *
+ * End-to-end coverage for the `/api/auth/github/refresh` route handler.
+ *
+ * Why these tests stay narrow:
+ *  In MSW test mode (`NEXT_PUBLIC_ENABLE_MSW_MOCK=true`, `APP_ENV=test`),
+ *  `hasGitHubToken()` short-circuits to `true` (axios-github.ts:131) so a
+ *  manually-cleared cookie does NOT surface `errorCode='GITHUB_TOKEN_MISSING'`.
+ *  That means the full client-hook → Server Action → route flow is not
+ *  reachable in the E2E harness. The hook + Server Action layers are covered
+ *  exhaustively by unit tests (see src/tests/unit/lib/utils/handle-github-
+ *  token-missing.test.ts and src/tests/unit/lib/actions/github-error-code.
+ *  test.ts).
+ *
+ *  These E2E tests target the route handler branches that are reachable
+ *  without going through the OAuth round-trip:
+ *   - Attempt cap exceeded (bails before any Supabase or rate-limit call)
+ *   - Open-redirect coercion (sanitization runs before any side effect)
+ */
+
+import { test, expect } from '../fixtures/coverage'
+
+test.describe('Silent GitHub token refresh — route handler', () => {
+  test.use({ storageState: 'e2e/.auth/user.json' })
+
+  test('redirects to /login?error=token_refresh_failed when ?attempt=2 exceeds the cap', async ({
+    page,
+  }) => {
+    // The handler bails immediately when attempt > MAX_REFRESH_ATTEMPTS (=1)
+    // before touching Supabase or rate-limit, so this is fully deterministic.
+    const response = await page.goto(
+      '/api/auth/github/refresh?next=/board/abc&attempt=2',
+    )
+
+    // Playwright follows redirects automatically — assert the final landing
+    // page rather than the 307 itself.
+    expect(page.url()).toContain('/login')
+    expect(page.url()).toContain('error=token_refresh_failed')
+    // The fetch chain that got us here should have started with a redirect.
+    expect(response?.request().redirectedFrom()).not.toBeNull()
+  })
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitbox",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "description": "A web application for managing GitHub repositories in Kanban board format",

--- a/src/app/api/auth/github/refresh/route.ts
+++ b/src/app/api/auth/github/refresh/route.ts
@@ -47,6 +47,27 @@ const log = createModuleLogger('github-token-refresh')
  */
 const MAX_REFRESH_ATTEMPTS = 1
 
+/**
+ * Route handler for `GET /api/auth/github/refresh`.
+ *
+ * Performs the silent re-authentication flow described in the file-level
+ * docblock above: enforces an attempt cap, applies per-IP rate limiting,
+ * verifies the Supabase session is still alive, then re-initiates GitHub
+ * OAuth and 302-redirects the browser to GitHub. On any failure the user
+ * lands on `/login?error=<code>` with a stable error code (no raw error
+ * messages are reflected into the URL).
+ *
+ * @param request - Incoming `Request` from Next.js. Read query params
+ *   (`next`, `attempt`) and the `x-real-ip` / `x-forwarded-for` headers.
+ * @returns A `NextResponse` redirect — either to GitHub's OAuth URL on
+ *   success, or to `/login?error=<code>` on failure (`token_refresh_failed`,
+ *   `rate_limited`, `oauth_failed`, `unexpected_error`).
+ *
+ * @example
+ *   // Client-side trigger
+ *   window.location.href =
+ *     `/api/auth/github/refresh?next=${encodeURIComponent('/board/abc')}`
+ */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
 
@@ -67,18 +88,22 @@ export async function GET(request: Request) {
 
   // Rate limit by IP. Reuses the `signInWithGitHub` bucket since each refresh
   // triggers a full GitHub OAuth round-trip — same upstream cost as a fresh
-  // sign-in.
+  // sign-in. Prefer `x-real-ip` (Vercel sets it to the trusted edge IP) over
+  // the first hop of `x-forwarded-for`, which is client-controllable when the
+  // proxy *appends* rather than replaces the header (Vercel's behavior).
+  const realIp = request.headers.get('x-real-ip')?.trim()
   const forwarded = getForwardedClientIp(request.headers)
-  if (!forwarded) {
-    log.warn('x-forwarded-for header missing — falling back to 127.0.0.1')
+  const clientIp = realIp || forwarded || '127.0.0.1'
+  if (!realIp && !forwarded) {
+    log.warn('No trusted client IP header found — falling back to 127.0.0.1')
   }
-  const clientIp = forwarded ?? '127.0.0.1'
   const rateLimitResult = checkRateLimit('signInWithGitHub', clientIp)
   if (!rateLimitResult.allowed) {
-    log.warn({ ip: clientIp }, 'Refresh rate limit exceeded')
-    return NextResponse.redirect(
-      `${origin}/login?error=rate_limited&message=${encodeURIComponent(rateLimitResult.error!)}`,
+    log.warn(
+      { ip: clientIp, error: rateLimitResult.error },
+      'Refresh rate limit exceeded',
     )
+    return NextResponse.redirect(`${origin}/login?error=rate_limited`)
   }
 
   const supabase = await createRouteHandlerClient(request)
@@ -95,6 +120,10 @@ export async function GET(request: Request) {
 
     if (userError || !user) {
       log.info({ next }, 'No Supabase session — redirecting to login')
+      logSecurityEvent('login_failure', {
+        error: 'no_session',
+        path: 'silent_token_refresh',
+      })
       return NextResponse.redirect(
         `${origin}/login?next=${encodeURIComponent(next)}`,
       )
@@ -120,9 +149,11 @@ export async function GET(request: Request) {
       Sentry.captureException(oauthError, {
         extra: { context: 'GitHub token refresh' },
       })
-      return NextResponse.redirect(
-        `${origin}/login?error=oauth_failed&message=${encodeURIComponent(oauthError.message)}`,
-      )
+      logSecurityEvent('login_failure', {
+        error: oauthError.message,
+        path: 'silent_token_refresh',
+      })
+      return NextResponse.redirect(`${origin}/login?error=oauth_failed`)
     }
 
     if (!data.url) {
@@ -131,9 +162,11 @@ export async function GET(request: Request) {
         'GitHub OAuth refresh: No redirect URL returned',
         'error',
       )
-      return NextResponse.redirect(
-        `${origin}/login?error=oauth_failed&message=No%20redirect%20URL%20returned`,
-      )
+      logSecurityEvent('login_failure', {
+        error: 'no_redirect_url',
+        path: 'silent_token_refresh',
+      })
+      return NextResponse.redirect(`${origin}/login?error=oauth_failed`)
     }
 
     logSecurityEvent('login_success', {
@@ -145,6 +178,13 @@ export async function GET(request: Request) {
     log.error({ error: unexpectedError }, 'Unexpected error in token refresh')
     Sentry.captureException(unexpectedError, {
       extra: { context: 'GitHub token refresh' },
+    })
+    logSecurityEvent('login_failure', {
+      error:
+        unexpectedError instanceof Error
+          ? unexpectedError.message
+          : 'unexpected_error',
+      path: 'silent_token_refresh',
     })
     return NextResponse.redirect(`${origin}/login?error=unexpected_error`)
   }

--- a/src/app/api/auth/github/refresh/route.ts
+++ b/src/app/api/auth/github/refresh/route.ts
@@ -35,47 +35,21 @@ import { createModuleLogger } from '@/lib/logger'
 import { checkRateLimit } from '@/lib/rate-limit/check'
 import { logSecurityEvent } from '@/lib/security-events'
 import { createRouteHandlerClient } from '@/lib/supabase/server'
+import { getForwardedClientIp } from '@/lib/utils/get-client-ip'
 import { sanitizeNextPath } from '@/lib/utils/sanitize-next'
 
 const log = createModuleLogger('github-token-refresh')
 
 /**
- * Maximum allowed `attempt` value before giving up.
- *
- * The client increments `attempt` each time it triggers a silent refresh.
- * On `attempt=2` (the second visit), this route fails to `/login` so the
- * user does not get stuck in a redirect loop when OAuth keeps failing to
- * land a usable provider token.
- *
- * One retry covers transient cookie write issues; a second visit means the
- * underlying issue is persistent (e.g., GitHub OAuth grant revoked) and
- * deserves a hard error instead of another silent attempt.
+ * Cap on silent refresh retries before forcing a hard `/login`. One retry
+ * covers transient cookie write failures; persistent failures (e.g., revoked
+ * OAuth grant) should surface to the user instead of looping.
  */
 const MAX_REFRESH_ATTEMPTS = 1
 
-/**
- * Handle silent GitHub token refresh.
- *
- * @param request - The inbound `Request`. Read for `x-forwarded-for` (IP for
- *   rate limiting) and the URL search params (`next`, `attempt`).
- * @returns A 302 `NextResponse.redirect`. Possible destinations:
- *   - GitHub OAuth URL (happy path)
- *   - `/login?next=<safe path>` when there is no Supabase session
- *   - `/login?error=token_refresh_failed` when the attempt cap is exceeded
- *   - `/login?error=oauth_failed&...` when `signInWithOAuth` errors
- *   - `/login?error=rate_limited&...` when the per-IP limit is exceeded
- *   - `/login?error=unexpected_error` for unhandled exceptions
- *
- * @example
- *   // GET /api/auth/github/refresh?next=/board/abc → 302 to GitHub OAuth
- *   // GET /api/auth/github/refresh?next=//evil.com → next coerced to /boards
- *   // GET /api/auth/github/refresh?attempt=2 → 302 /login?error=token_refresh_failed
- */
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
 
-  // Sanitize `next` — only allow safe relative paths.
-  // Shared with src/app/auth/callback/route.ts via sanitizeNextPath.
   const next = sanitizeNextPath(searchParams.get('next'), '/boards')
 
   // Bail if the attempt count exceeds the cap (prevents infinite loops).
@@ -94,14 +68,11 @@ export async function GET(request: Request) {
   // Rate limit by IP. Reuses the `signInWithGitHub` bucket since each refresh
   // triggers a full GitHub OAuth round-trip — same upstream cost as a fresh
   // sign-in.
-  const forwarded = request.headers
-    .get('x-forwarded-for')
-    ?.split(',')[0]
-    ?.trim()
+  const forwarded = getForwardedClientIp(request.headers)
   if (!forwarded) {
     log.warn('x-forwarded-for header missing — falling back to 127.0.0.1')
   }
-  const clientIp = forwarded || '127.0.0.1'
+  const clientIp = forwarded ?? '127.0.0.1'
   const rateLimitResult = checkRateLimit('signInWithGitHub', clientIp)
   if (!rateLimitResult.allowed) {
     log.warn({ ip: clientIp }, 'Refresh rate limit exceeded')
@@ -165,8 +136,6 @@ export async function GET(request: Request) {
       )
     }
 
-    // The path 'silent_token_refresh' identifies this login_success entry as
-    // a silent re-auth (vs. initial OAuth in /auth/callback) for audit trails.
     logSecurityEvent('login_success', {
       userId: user.id,
       path: 'silent_token_refresh',

--- a/src/app/api/auth/github/refresh/route.ts
+++ b/src/app/api/auth/github/refresh/route.ts
@@ -1,0 +1,182 @@
+/**
+ * GitHub Token Refresh Endpoint
+ *
+ * Silent re-authentication when the GitHub `provider_token` cookie is missing
+ * but the Supabase session is still valid. This happens when a user returns
+ * after the GitHub provider token (8h–30d) has expired or the cookie was
+ * cleared, while Supabase's longer-lived refresh token (~30d) is still alive.
+ *
+ * Flow:
+ *  1. A Server Action returns `errorCode: 'GITHUB_TOKEN_MISSING'` (see
+ *     `src/lib/actions/types.ts`).
+ *  2. The client hook in `src/lib/utils/handle-github-token-missing.ts`
+ *     redirects the browser to `/api/auth/github/refresh?next=<current path>`.
+ *  3. This route checks the Supabase session, then re-initiates GitHub OAuth.
+ *  4. After GitHub OAuth, `/auth/callback` exchanges the code, sets a fresh
+ *     `provider_token` cookie via `setGitHubTokenCookie`, and redirects to
+ *     `<next>`.
+ *
+ * Defenses:
+ *  - Open-redirect prevention on `next` (mirrors `/auth/callback`)
+ *  - Attempt cap to break infinite redirect loops if OAuth keeps failing
+ *  - Rate limit by IP (reuses the `signInWithGitHub` bucket)
+ *  - Supabase session check: refresh requires existing login
+ *
+ * @example
+ *   // From a client hook
+ *   window.location.href =
+ *     `/api/auth/github/refresh?next=${encodeURIComponent('/board/123')}`
+ */
+
+import * as Sentry from '@sentry/nextjs'
+import { NextResponse } from 'next/server'
+
+import { createModuleLogger } from '@/lib/logger'
+import { checkRateLimit } from '@/lib/rate-limit/check'
+import { logSecurityEvent } from '@/lib/security-events'
+import { createRouteHandlerClient } from '@/lib/supabase/server'
+import { sanitizeNextPath } from '@/lib/utils/sanitize-next'
+
+const log = createModuleLogger('github-token-refresh')
+
+/**
+ * Maximum allowed `attempt` value before giving up.
+ *
+ * The client increments `attempt` each time it triggers a silent refresh.
+ * On `attempt=2` (the second visit), this route fails to `/login` so the
+ * user does not get stuck in a redirect loop when OAuth keeps failing to
+ * land a usable provider token.
+ *
+ * One retry covers transient cookie write issues; a second visit means the
+ * underlying issue is persistent (e.g., GitHub OAuth grant revoked) and
+ * deserves a hard error instead of another silent attempt.
+ */
+const MAX_REFRESH_ATTEMPTS = 1
+
+/**
+ * Handle silent GitHub token refresh.
+ *
+ * @param request - The inbound `Request`. Read for `x-forwarded-for` (IP for
+ *   rate limiting) and the URL search params (`next`, `attempt`).
+ * @returns A 302 `NextResponse.redirect`. Possible destinations:
+ *   - GitHub OAuth URL (happy path)
+ *   - `/login?next=<safe path>` when there is no Supabase session
+ *   - `/login?error=token_refresh_failed` when the attempt cap is exceeded
+ *   - `/login?error=oauth_failed&...` when `signInWithOAuth` errors
+ *   - `/login?error=rate_limited&...` when the per-IP limit is exceeded
+ *   - `/login?error=unexpected_error` for unhandled exceptions
+ *
+ * @example
+ *   // GET /api/auth/github/refresh?next=/board/abc → 302 to GitHub OAuth
+ *   // GET /api/auth/github/refresh?next=//evil.com → next coerced to /boards
+ *   // GET /api/auth/github/refresh?attempt=2 → 302 /login?error=token_refresh_failed
+ */
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+
+  // Sanitize `next` — only allow safe relative paths.
+  // Shared with src/app/auth/callback/route.ts via sanitizeNextPath.
+  const next = sanitizeNextPath(searchParams.get('next'), '/boards')
+
+  // Bail if the attempt count exceeds the cap (prevents infinite loops).
+  const rawAttempt = Number.parseInt(searchParams.get('attempt') ?? '1', 10)
+  const attempt =
+    Number.isFinite(rawAttempt) && rawAttempt >= 1 ? rawAttempt : 1
+
+  if (attempt > MAX_REFRESH_ATTEMPTS) {
+    log.warn({ attempt, next }, 'Silent refresh attempt cap exceeded')
+    logSecurityEvent('login_failure', {
+      error: 'refresh_attempt_cap_exceeded',
+    })
+    return NextResponse.redirect(`${origin}/login?error=token_refresh_failed`)
+  }
+
+  // Rate limit by IP. Reuses the `signInWithGitHub` bucket since each refresh
+  // triggers a full GitHub OAuth round-trip — same upstream cost as a fresh
+  // sign-in.
+  const forwarded = request.headers
+    .get('x-forwarded-for')
+    ?.split(',')[0]
+    ?.trim()
+  if (!forwarded) {
+    log.warn('x-forwarded-for header missing — falling back to 127.0.0.1')
+  }
+  const clientIp = forwarded || '127.0.0.1'
+  const rateLimitResult = checkRateLimit('signInWithGitHub', clientIp)
+  if (!rateLimitResult.allowed) {
+    log.warn({ ip: clientIp }, 'Refresh rate limit exceeded')
+    return NextResponse.redirect(
+      `${origin}/login?error=rate_limited&message=${encodeURIComponent(rateLimitResult.error!)}`,
+    )
+  }
+
+  const supabase = await createRouteHandlerClient(request)
+
+  try {
+    // The Supabase session must still be valid. If the user logged out, the
+    // session expired, or cookies were cleared, refresh is meaningless —
+    // bounce them to /login with `next` preserved so they end up where they
+    // intended after a fresh sign-in.
+    const {
+      data: { user },
+      error: userError,
+    } = await supabase.auth.getUser()
+
+    if (userError || !user) {
+      log.info({ next }, 'No Supabase session — redirecting to login')
+      return NextResponse.redirect(
+        `${origin}/login?next=${encodeURIComponent(next)}`,
+      )
+    }
+
+    // Re-initiate GitHub OAuth. The PKCE `code_verifier` cookie is set by
+    // the Supabase route-handler client via the cookies() adapter, and Next
+    // propagates the cookie mutation onto the redirect response automatically.
+    // /auth/callback then reads `next` from the query string and lands the
+    // user back on the original page once the new token cookie is in place.
+    const callbackUrl = `${origin}/auth/callback?next=${encodeURIComponent(next)}`
+
+    const { data, error: oauthError } = await supabase.auth.signInWithOAuth({
+      provider: 'github',
+      options: {
+        redirectTo: callbackUrl,
+        scopes: 'read:user user:email repo',
+      },
+    })
+
+    if (oauthError) {
+      log.error({ error: oauthError.message }, 'OAuth refresh failed')
+      Sentry.captureException(oauthError, {
+        extra: { context: 'GitHub token refresh' },
+      })
+      return NextResponse.redirect(
+        `${origin}/login?error=oauth_failed&message=${encodeURIComponent(oauthError.message)}`,
+      )
+    }
+
+    if (!data.url) {
+      log.error('OAuth refresh: no redirect URL returned')
+      Sentry.captureMessage(
+        'GitHub OAuth refresh: No redirect URL returned',
+        'error',
+      )
+      return NextResponse.redirect(
+        `${origin}/login?error=oauth_failed&message=No%20redirect%20URL%20returned`,
+      )
+    }
+
+    // The path 'silent_token_refresh' identifies this login_success entry as
+    // a silent re-auth (vs. initial OAuth in /auth/callback) for audit trails.
+    logSecurityEvent('login_success', {
+      userId: user.id,
+      path: 'silent_token_refresh',
+    })
+    return NextResponse.redirect(data.url)
+  } catch (unexpectedError) {
+    log.error({ error: unexpectedError }, 'Unexpected error in token refresh')
+    Sentry.captureException(unexpectedError, {
+      extra: { context: 'GitHub token refresh' },
+    })
+    return NextResponse.redirect(`${origin}/login?error=unexpected_error`)
+  }
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -24,24 +24,8 @@ export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get('code')
 
-  /**
-   * Post-authentication redirect destination.
-   *
-   * The `next` query parameter allows redirecting users back to their original
-   * destination after successful authentication. This enables a "return to
-   * original page" flow for protected routes.
-   *
-   * @example Intended usage flow (not yet implemented in middleware):
-   * 1. User visits /board/123 (unauthenticated)
-   * 2. Middleware redirects to /login?next=/board/123
-   * 3. Login page initiates OAuth with redirectTo: /auth/callback?next=/board/123
-   * 4. After successful auth, user is redirected to /board/123
-   *
-   * @default '/boards' - If `next` is not provided, redirects to the main boards page
-   * @note Set by /api/auth/github/refresh on silent re-auth (refresh/route.ts:142). Also reserved for future link sources (e.g., middleware redirects on protected routes).
-   */
-  // Sanitize `next` — only allow safe relative paths.
-  // Shared with src/app/api/auth/github/refresh/route.ts via sanitizeNextPath.
+  // Set by /api/auth/github/refresh on silent re-auth and reserved for future
+  // middleware-driven "return to original page" flows on protected routes.
   const next = sanitizeNextPath(searchParams.get('next'), '/boards')
 
   if (code) {

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -9,14 +9,14 @@
  * - Redirects to Boards screen
  */
 
-import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 
 import { createFirstBoardIfNeeded } from '@/lib/actions/board'
-import { getGitHubTokenCookieName } from '@/lib/constants/cookies'
+import { setGitHubTokenCookie } from '@/lib/constants/cookies'
 import { createModuleLogger } from '@/lib/logger'
 import { logSecurityEvent } from '@/lib/security-events'
 import { createRouteHandlerClient } from '@/lib/supabase/server'
+import { sanitizeNextPath } from '@/lib/utils/sanitize-next'
 
 const log = createModuleLogger('auth-callback')
 
@@ -38,17 +38,11 @@ export async function GET(request: Request) {
    * 4. After successful auth, user is redirected to /board/123
    *
    * @default '/boards' - If `next` is not provided, redirects to the main boards page
-   * @note Currently, no code sets this parameter; it exists for future extensibility
+   * @note Set by /api/auth/github/refresh on silent re-auth (refresh/route.ts:142). Also reserved for future link sources (e.g., middleware redirects on protected routes).
    */
-  const rawNext = searchParams.get('next') ?? '/boards'
-  // Prevent open redirect: only allow relative paths, block protocol-relative URLs
-  // Also block backslash variants (/\evil.com) — WHATWG URL Standard normalizes \ to / for http/https
-  const next =
-    rawNext.startsWith('/') &&
-    !rawNext.startsWith('//') &&
-    !rawNext.includes('\\')
-      ? rawNext
-      : '/boards'
+  // Sanitize `next` — only allow safe relative paths.
+  // Shared with src/app/api/auth/github/refresh/route.ts via sanitizeNextPath.
+  const next = sanitizeNextPath(searchParams.get('next'), '/boards')
 
   if (code) {
     const supabase = await createRouteHandlerClient(request)
@@ -68,15 +62,7 @@ export async function GET(request: Request) {
       // Retrieve provider_token and save to cookie (for GitHub API access)
       const providerToken = data.session?.provider_token
       if (providerToken) {
-        const cookieStore = await cookies()
-        const cookieName = getGitHubTokenCookieName()
-        cookieStore.set(cookieName, providerToken, {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === 'production',
-          sameSite: 'lax',
-          maxAge: 60 * 60 * 8, // 8 hours — aligned with GitHub fine-grained token default TTL
-          path: '/',
-        })
+        await setGitHubTokenCookie(providerToken)
       } else {
         log.warn(
           'No provider_token in session - GitHub API access may be limited',

--- a/src/hooks/board/useOrganizationData.ts
+++ b/src/hooks/board/useOrganizationData.ts
@@ -19,6 +19,10 @@ import {
   type GitHubUser,
   type GitHubOrganization,
 } from '@/lib/actions/github'
+import {
+  clearGitHubRefreshAttempts,
+  handleGitHubTokenMissing,
+} from '@/lib/utils/handle-github-token-missing'
 
 interface UseOrganizationDataReturn {
   currentUser: GitHubUser | null
@@ -50,12 +54,35 @@ export function useOrganizationData(
         getAuthenticatedUserOrganizations(),
       ])
 
+      // If either call surfaces a missing token, fire silent refresh once.
+      // The handler is idempotent, so duplicate calls from this hook + the
+      // sibling useRepositoryData hook collapse into a single redirect.
+      const hasTokenMissing =
+        (!userResult.success &&
+          userResult.errorCode === 'GITHUB_TOKEN_MISSING') ||
+        (!orgsResult.success && orgsResult.errorCode === 'GITHUB_TOKEN_MISSING')
+      if (hasTokenMissing) {
+        const wasHandledByRefresh = handleGitHubTokenMissing(
+          window.location.pathname,
+        )
+        if (wasHandledByRefresh) return
+        // Iframe context: the handler can't navigate, so fall through to
+        // populate whichever calls succeeded. The combobox renders the
+        // partial data; useRepositoryData surfaces the auth error.
+      }
+
       if (userResult.success) {
         setCurrentUser(userResult.data)
       }
 
       if (orgsResult.success) {
         setOrganizations(orgsResult.data)
+      }
+
+      // At least one call succeeded means the token is alive — reset the
+      // refresh attempt counter so a future expiry starts fresh from 1.
+      if (userResult.success || orgsResult.success) {
+        clearGitHubRefreshAttempts()
       }
     } catch (error) {
       Sentry.captureException(error, { tags: { action: 'fetchOrganizations' } })

--- a/src/hooks/board/useRepositoryData.ts
+++ b/src/hooks/board/useRepositoryData.ts
@@ -18,6 +18,10 @@ import {
   type GitHubRepository,
   type GitHubOrganization,
 } from '@/lib/actions/github'
+import {
+  clearGitHubRefreshAttempts,
+  handleGitHubTokenMissing,
+} from '@/lib/utils/handle-github-token-missing'
 
 interface UseRepositoryDataReturn {
   userRepos: GitHubRepository[]
@@ -54,10 +58,18 @@ export function useRepositoryData(
       })
 
       if (!result.success) {
+        if (result.errorCode === 'GITHUB_TOKEN_MISSING') {
+          const wasHandledByRefresh = handleGitHubTokenMissing(
+            window.location.pathname,
+          )
+          if (wasHandledByRefresh) return
+        }
         setReposError(result.error)
         setUserRepos([])
         return
       }
+
+      clearGitHubRefreshAttempts()
 
       const allRepos = [...result.data]
 
@@ -67,6 +79,25 @@ export function useRepositoryData(
           getOrganizationRepositories(org.login, { fetchAll: true }),
         )
         const orgResults = await Promise.all(orgRepoPromises)
+
+        // If any org call surfaced a missing token, the cookie went stale
+        // mid-batch — trigger silent refresh and abort the merge.
+        const hasOrgTokenMissing = orgResults.some(
+          (orgResult) =>
+            !orgResult.success &&
+            orgResult.errorCode === 'GITHUB_TOKEN_MISSING',
+        )
+        if (hasOrgTokenMissing) {
+          const wasHandledByRefresh = handleGitHubTokenMissing(
+            window.location.pathname,
+          )
+          if (wasHandledByRefresh) return
+          // Iframe context: keep the user repos we already fetched and surface
+          // an auth error so the UI shows something rather than blanking out.
+          setReposError('GitHub authentication required. Please sign in again.')
+          setUserRepos(allRepos)
+          return
+        }
 
         const existingIds = new Set(allRepos.map((repo) => repo.id))
         for (const orgResult of orgResults) {

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -20,6 +20,7 @@ import {
   createServerActionClient,
   createAdminClient,
 } from '@/lib/supabase/server'
+import { getForwardedClientIp } from '@/lib/utils/get-client-ip'
 
 /**
  * Sign in with GitHub OAuth
@@ -29,14 +30,14 @@ import {
 export async function signInWithGitHub() {
   // Rate limit by IP (user not yet authenticated)
   const headerStore = await headers()
-  const forwarded = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
+  const forwarded = getForwardedClientIp(headerStore)
   if (!forwarded) {
     Sentry.captureMessage('signInWithGitHub: x-forwarded-for header missing', {
       level: 'warning',
       tags: { category: 'rate_limit' },
     })
   }
-  const ip = forwarded || '127.0.0.1'
+  const ip = forwarded ?? '127.0.0.1'
   const rlResult = checkRateLimit('signInWithGitHub', ip)
   if (!rlResult.allowed) {
     redirect(

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -10,10 +10,10 @@
 'use server'
 
 import * as Sentry from '@sentry/nextjs'
-import { cookies, headers } from 'next/headers'
+import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
-import { getGitHubTokenCookieName } from '@/lib/constants/cookies'
+import { deleteGitHubTokenCookie } from '@/lib/constants/cookies'
 import { checkRateLimit } from '@/lib/rate-limit/check'
 import { logSecurityEvent } from '@/lib/security-events'
 import {
@@ -85,7 +85,6 @@ export async function signInWithGitHub() {
  */
 export async function signOut() {
   const supabase = await createServerActionClient()
-  const cookieStore = await cookies()
 
   const { error } = await supabase.auth.signOut()
 
@@ -94,9 +93,7 @@ export async function signOut() {
     throw new Error(error.message)
   }
 
-  // Delete GitHub provider token cookie
-  const githubTokenCookieName = getGitHubTokenCookieName()
-  cookieStore.delete(githubTokenCookieName)
+  await deleteGitHubTokenCookie()
 
   logSecurityEvent('logout')
 
@@ -115,7 +112,6 @@ export async function signOut() {
  */
 export async function deleteAccount() {
   const supabase = await createServerActionClient()
-  const cookieStore = await cookies()
 
   // Get current user
   const {
@@ -151,10 +147,7 @@ export async function deleteAccount() {
 
   logSecurityEvent('account_deleted', { userId: user.id })
 
-  // Delete GitHub provider token cookie
-  const githubTokenCookieName = getGitHubTokenCookieName()
-  cookieStore.delete(githubTokenCookieName)
+  await deleteGitHubTokenCookie()
 
-  // Redirect to landing page
   redirect('/')
 }

--- a/src/lib/actions/github.ts
+++ b/src/lib/actions/github.ts
@@ -26,6 +26,15 @@ import type { ActionResult } from './types'
 const log = createModuleLogger('github')
 
 /**
+ * User-facing message shown when the GitHub provider_token cookie is missing.
+ *
+ * Paired with `errorCode: 'GITHUB_TOKEN_MISSING'` so the client can trigger
+ * silent re-auth via `/api/auth/github/refresh` instead of surfacing this
+ * to the UI as an error.
+ */
+const TOKEN_MISSING_ERROR_MSG = 'GitHub token not found. Please sign in again.'
+
+/**
  * Get client IP from request headers for rate limiting.
  * GitHub API functions don't use Supabase auth, so we use IP-based limiting.
  * Logs a warning when x-forwarded-for is missing (proxy misconfiguration).
@@ -169,7 +178,8 @@ export async function getAuthenticatedUserRepositories(params?: {
   if (!(await hasGitHubToken())) {
     return {
       success: false,
-      error: 'GitHub token not found. Please sign in again.',
+      error: TOKEN_MISSING_ERROR_MSG,
+      errorCode: 'GITHUB_TOKEN_MISSING',
     }
   }
 
@@ -251,7 +261,8 @@ export async function getAuthenticatedUser(): Promise<
   if (!(await hasGitHubToken())) {
     return {
       success: false,
-      error: 'GitHub token not found. Please sign in again.',
+      error: TOKEN_MISSING_ERROR_MSG,
+      errorCode: 'GITHUB_TOKEN_MISSING',
     }
   }
 
@@ -299,7 +310,8 @@ export async function getOrganizationRepositories(
   if (!(await hasGitHubToken())) {
     return {
       success: false,
-      error: 'GitHub token not found. Please sign in again.',
+      error: TOKEN_MISSING_ERROR_MSG,
+      errorCode: 'GITHUB_TOKEN_MISSING',
     }
   }
 
@@ -383,7 +395,8 @@ export async function getAuthenticatedUserOrganizations(): Promise<
   if (!(await hasGitHubToken())) {
     return {
       success: false,
-      error: 'GitHub token not found. Please sign in again.',
+      error: TOKEN_MISSING_ERROR_MSG,
+      errorCode: 'GITHUB_TOKEN_MISSING',
     }
   }
 

--- a/src/lib/actions/github.ts
+++ b/src/lib/actions/github.ts
@@ -20,6 +20,7 @@ import type {
   GitHubAccountType,
   Visibility,
 } from '@/lib/types/domain-primitives'
+import { getForwardedClientIp } from '@/lib/utils/get-client-ip'
 
 import type { ActionResult } from './types'
 
@@ -35,17 +36,15 @@ const log = createModuleLogger('github')
 const TOKEN_MISSING_ERROR_MSG = 'GitHub token not found. Please sign in again.'
 
 /**
- * Get client IP from request headers for rate limiting.
- * GitHub API functions don't use Supabase auth, so we use IP-based limiting.
- * Logs a warning when x-forwarded-for is missing (proxy misconfiguration).
+ * Resolve client IP for IP-based rate limiting (GitHub Server Actions skip
+ * Supabase auth). Warns once per call when the proxy did not set the header.
  */
 async function getClientIp(): Promise<string> {
-  const headerStore = await headers()
-  const forwarded = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
-  if (!forwarded) {
+  const ip = getForwardedClientIp(await headers())
+  if (!ip) {
     log.warn('x-forwarded-for header missing — falling back to 127.0.0.1')
   }
-  return forwarded || '127.0.0.1'
+  return ip ?? '127.0.0.1'
 }
 
 /**

--- a/src/lib/actions/public-board.ts
+++ b/src/lib/actions/public-board.ts
@@ -54,9 +54,11 @@ export interface PublicBoardData {
 export async function getPublicBoardBySlug(
   slug: PublicBoardSlug,
 ): Promise<PublicBoardData | null> {
-  // Rate limit by IP — anonymous endpoint, so 'unknown' (not loopback) is the
-  // semantically correct fallback when there is no proxy header.
-  const ip = getForwardedClientIp(await headers()) ?? 'unknown'
+  // Rate limit by IP — anonymous endpoint. When there is no proxy header
+  // (rare in production), fall back to a per-request UUID so headerless
+  // traffic does not collapse into a single shared bucket where one client
+  // can throttle every other anonymous viewer.
+  const ip = getForwardedClientIp(await headers()) ?? crypto.randomUUID()
   const rl = checkRateLimit('publicBoardView', ip)
   if (!rl.allowed) return null
 

--- a/src/lib/actions/public-board.ts
+++ b/src/lib/actions/public-board.ts
@@ -20,6 +20,7 @@ import {
   type PublicBoardSlug,
 } from '@/lib/types/brands'
 import type { ISOTimestamp, ShareSlug } from '@/lib/types/domain-primitives'
+import { getForwardedClientIp } from '@/lib/utils/get-client-ip'
 
 /** Public-safe board fields (excludes user_id) */
 interface PublicBoard {
@@ -53,10 +54,9 @@ export interface PublicBoardData {
 export async function getPublicBoardBySlug(
   slug: PublicBoardSlug,
 ): Promise<PublicBoardData | null> {
-  // Rate limit by IP
-  const headerStore = await headers()
-  const ip =
-    headerStore.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown'
+  // Rate limit by IP — anonymous endpoint, so 'unknown' (not loopback) is the
+  // semantically correct fallback when there is no proxy header.
+  const ip = getForwardedClientIp(await headers()) ?? 'unknown'
   const rl = checkRateLimit('publicBoardView', ip)
   if (!rl.allowed) return null
 

--- a/src/lib/actions/types.ts
+++ b/src/lib/actions/types.ts
@@ -31,15 +31,29 @@
  */
 
 /**
+ * Machine-readable error codes for Server Action failures.
+ *
+ * Use sparingly — only add a code when the client needs to branch on it
+ * (e.g., trigger silent re-auth on `GITHUB_TOKEN_MISSING`). The human-readable
+ * `error` field remains the source of UI copy.
+ *
+ * @example
+ * if (!result.success && result.errorCode === 'GITHUB_TOKEN_MISSING') {
+ *   handleGitHubTokenMissing(window.location.pathname)
+ * }
+ */
+export type ActionErrorCode = 'GITHUB_TOKEN_MISSING'
+
+/**
  * Discriminated union for Server Action results.
  *
  * @param T - The data type on success
- * @returns Either `{ success: true, data: T }` or `{ success: false, error: string }`
+ * @returns Either `{ success: true, data: T }` or `{ success: false, error: string, errorCode?: ActionErrorCode }`
  *
  * @example
  * type Result = ActionResult<User[]>
- * // => { success: true; data: User[] } | { success: false; error: string }
+ * // => { success: true; data: User[] } | { success: false; error: string; errorCode?: ActionErrorCode }
  */
 export type ActionResult<T> =
   | { success: true; data: T }
-  | { success: false; error: string }
+  | { success: false; error: string; errorCode?: ActionErrorCode }

--- a/src/lib/axios-github.ts
+++ b/src/lib/axios-github.ts
@@ -14,7 +14,10 @@ import axios, {
 } from 'axios'
 import { cookies } from 'next/headers'
 
-import { getGitHubTokenCookieName } from '@/lib/constants/cookies'
+import {
+  deleteGitHubTokenCookie,
+  getGitHubTokenCookieName,
+} from '@/lib/constants/cookies'
 
 const GITHUB_API_BASE_URL = 'https://api.github.com'
 
@@ -98,9 +101,7 @@ export function createGitHubAxios(): AxiosInstance {
   instance.interceptors.response.use(undefined, async (error) => {
     if (axios.isAxiosError(error) && error.response?.status === 401) {
       try {
-        const cookieStore = await cookies()
-        const cookieName = getGitHubTokenCookieName()
-        cookieStore.delete(cookieName)
+        await deleteGitHubTokenCookie()
       } catch {
         // Cookie deletion may fail in certain Next.js contexts (e.g., static
         // generation). Silently ignore — the token will expire naturally.

--- a/src/lib/constants/cookies.ts
+++ b/src/lib/constants/cookies.ts
@@ -1,9 +1,39 @@
 /**
- * Cookie Name Constants
+ * Cookie Name Constants & Helpers
  *
- * Environment-specific cookie names to prevent conflicts
- * when running dev and prod environments on localhost.
+ * Environment-specific cookie names + typed setter/deleter for the GitHub
+ * provider_token cookie. Centralizes cookie options so a maxAge typo cannot
+ * silently re-introduce the "GitHub token not found after a few hours" bug.
  */
+
+import { cookies } from 'next/headers'
+
+/**
+ * Lifetime of the `gh_token_*` cookie holding the GitHub OAuth provider_token.
+ *
+ * **Value:** 30 days (matches Supabase `refresh_token` default TTL).
+ *
+ * **Why 30 days, not "forever"?**
+ * - Supabase refresh_token also expires at ~30 days, so any longer TTL is wasted —
+ *   the user must re-auth Supabase first, which re-issues the provider_token anyway.
+ * - The GitHub OAuth App is configured with "Token expiration: OFF" (non-expiring
+ *   tokens). The 30-day client-side cookie is our trust horizon, not GitHub's.
+ *
+ * **Security tradeoff (cookie theft replay window):**
+ * - Cookie carries a token with `repo` scope (read/write private repos).
+ * - If stolen, attacker has up to 30 days of API access on this user's GitHub.
+ * - Mitigations in place:
+ *   - `httpOnly: true` — JavaScript cannot read the cookie (XSS resistant).
+ *   - `secure: production` — only sent over HTTPS in prod.
+ *   - `sameSite: 'lax'` — not sent on cross-site subrequests.
+ *   - 401 interceptor in `axios-github.ts` auto-deletes the cookie when GitHub
+ *     rejects the token, shrinking the window if the token is revoked.
+ *   - Silent re-auth via `/api/auth/github/refresh` is rate-limited per IP.
+ * - Residual risk: full session-token theft (e.g., malicious browser extension)
+ *   gives the same 30 days of access. Acceptable — same risk profile as the
+ *   Supabase JWT.
+ */
+export const GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
 
 /**
  * Get environment-specific GitHub token cookie name
@@ -25,4 +55,42 @@ export function getGitHubTokenCookieName(): string {
   const match = supabaseUrl.match(/https:\/\/([a-z0-9]+)\.supabase\.co/)
   const projectId = match?.[1]?.slice(0, 8) || 'default'
   return `gh_token_${projectId}`
+}
+
+/**
+ * Persist the GitHub OAuth provider_token in an httpOnly cookie.
+ *
+ * Called on:
+ * - Initial OAuth callback (`src/app/auth/callback/route.ts`)
+ * - Silent re-auth callback (same callback, post `/api/auth/github/refresh`)
+ *
+ * @param token - GitHub provider_token from `data.session.provider_token`
+ * @example
+ * await setGitHubTokenCookie(providerToken)
+ */
+export async function setGitHubTokenCookie(token: string): Promise<void> {
+  const cookieStore = await cookies()
+  cookieStore.set(getGitHubTokenCookieName(), token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS,
+    path: '/',
+  })
+}
+
+/**
+ * Remove the GitHub OAuth provider_token cookie.
+ *
+ * Called on:
+ * - Sign out (`src/lib/actions/auth.ts`)
+ * - Account deletion (`src/lib/actions/auth.ts`)
+ * - 401 response from GitHub API (`src/lib/axios-github.ts`)
+ *
+ * @example
+ * await deleteGitHubTokenCookie()
+ */
+export async function deleteGitHubTokenCookie(): Promise<void> {
+  const cookieStore = await cookies()
+  cookieStore.delete(getGitHubTokenCookieName())
 }

--- a/src/lib/utils/get-client-ip.ts
+++ b/src/lib/utils/get-client-ip.ts
@@ -1,0 +1,19 @@
+/**
+ * Read the first-hop client IP from `x-forwarded-for`.
+ *
+ * The header value is a comma-separated chain (`client, proxy1, proxy2`);
+ * the first entry is the original client. Returns `null` when the header
+ * is absent or empty so callers can distinguish "no proxy header" from
+ * "client genuinely on the loopback address" and choose their own fallback
+ * + missing-header logging strategy.
+ *
+ * @param headers - `next/headers()` result (Server Actions) or `request.headers` (Route Handlers).
+ * @returns First-hop IP (trimmed), or `null` when missing.
+ *
+ * @example
+ *   getForwardedClientIp(await headers())  // => '203.0.113.1' or null
+ *   getForwardedClientIp(request.headers)  // => '203.0.113.1' or null
+ */
+export function getForwardedClientIp(headers: Headers): string | null {
+  return headers.get('x-forwarded-for')?.split(',')[0]?.trim() || null
+}

--- a/src/lib/utils/handle-github-token-missing.ts
+++ b/src/lib/utils/handle-github-token-missing.ts
@@ -1,0 +1,144 @@
+/**
+ * Silent GitHub Token Refresh Trigger
+ *
+ * Client-side helper called when a Server Action returns
+ * `errorCode: 'GITHUB_TOKEN_MISSING'`. Redirects the browser to the
+ * `/api/auth/github/refresh` route, which re-initiates GitHub OAuth and
+ * returns the user to the original page once a fresh provider token
+ * cookie is in place.
+ *
+ * Two layers of idempotency keep this safe:
+ *  1. Module-level `isRefreshInFlight` flag prevents duplicate redirects
+ *     when several hooks fire `Promise.all` against GitHub Server Actions
+ *     in parallel and all receive the same `GITHUB_TOKEN_MISSING` error.
+ *  2. `sessionStorage` counter persists across the OAuth round-trip so
+ *     that if a refresh fails to land a usable token, the next visit
+ *     surfaces a hard error to the user instead of looping forever.
+ *
+ * Cleanup: callers MUST invoke `clearGitHubRefreshAttempts()` whenever a
+ * GitHub Server Action succeeds, so the counter resets after the token
+ * starts working again.
+ *
+ * @example
+ *   const result = await getAuthenticatedUserRepositories()
+ *   if (result.success) {
+ *     clearGitHubRefreshAttempts()
+ *     return result.data
+ *   }
+ *   if (result.errorCode === 'GITHUB_TOKEN_MISSING') {
+ *     handleGitHubTokenMissing(window.location.pathname)
+ *     return undefined
+ *   }
+ */
+
+const REFRESH_ATTEMPTS_STORAGE_KEY = 'gh_refresh_attempts'
+
+/**
+ * Page-lifetime lock preventing duplicate redirects when many hooks see
+ * the same `GITHUB_TOKEN_MISSING` error simultaneously. The browser-level
+ * navigation triggered by `window.location.href = ...` is asynchronous, so
+ * subsequent calls within the same JS tick must short-circuit until the
+ * page actually navigates away (and the module is re-evaluated).
+ */
+let isRefreshInFlight = false
+
+/**
+ * Trigger silent re-authentication by navigating to the refresh route.
+ *
+ * @param currentPath - Path to return to after OAuth (e.g., '/board/abc').
+ *   Forwarded as `?next=<path>` and ultimately validated server-side.
+ * @returns
+ *   - `true` when the handler took over (either initiated a redirect now,
+ *     or another redirect is already in flight from a sibling hook).
+ *     Caller should NOT set error UI state — the page is unloading.
+ *   - `false` when the handler is a no-op for environmental reasons (SSR,
+ *     iframe context). Caller SHOULD fall through to its existing error UI.
+ *
+ * @example
+ *   const handled = handleGitHubTokenMissing(window.location.pathname)
+ *   if (!handled) setReposError(result.error)
+ */
+export function handleGitHubTokenMissing(currentPath: string): boolean {
+  if (typeof window === 'undefined') return false
+  if (isRefreshInFlight) return true
+
+  // Embedded contexts (Storybook test orchestrator, third-party iframe
+  // embeds) cannot have window.location.href reassigned without breaking
+  // the parent. Fall back to the surrounding error UI in those cases.
+  if (window.parent !== window) return false
+
+  isRefreshInFlight = true
+
+  // sessionStorage can throw in Safari private mode or when quota is exceeded.
+  // Fall back to a single-attempt refresh (counter not persisted) if so —
+  // the server-side rate limit still bounds total refreshes per IP.
+  let nextAttempt = 1
+  try {
+    const previousAttemptsRaw = window.sessionStorage.getItem(
+      REFRESH_ATTEMPTS_STORAGE_KEY,
+    )
+    const previousAttempts =
+      previousAttemptsRaw === null
+        ? 0
+        : parseStoredAttempts(previousAttemptsRaw)
+    nextAttempt = previousAttempts + 1
+    window.sessionStorage.setItem(
+      REFRESH_ATTEMPTS_STORAGE_KEY,
+      String(nextAttempt),
+    )
+  } catch {
+    // Storage unavailable — proceed with attempt=1.
+  }
+
+  const params = new URLSearchParams()
+  params.set('next', currentPath)
+  // The server treats a missing `attempt` param as 1, so we only emit it
+  // on the second visit. Keeps the happy-path URL clean.
+  if (nextAttempt > 1) {
+    params.set('attempt', String(nextAttempt))
+  }
+  window.location.href = `/api/auth/github/refresh?${params.toString()}`
+  return true
+}
+
+/**
+ * Reset the refresh attempt counter.
+ *
+ * Call this from any GitHub Server Action success path so the counter
+ * does not carry over from a previous failed refresh into a fresh tab
+ * session.
+ *
+ * @example
+ *   const result = await getAuthenticatedUserRepositories()
+ *   if (result.success) {
+ *     clearGitHubRefreshAttempts()
+ *     return result.data
+ *   }
+ */
+export function clearGitHubRefreshAttempts(): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.sessionStorage.removeItem(REFRESH_ATTEMPTS_STORAGE_KEY)
+  } catch {
+    // Storage may throw in Safari private mode; safe to ignore.
+  }
+}
+
+/**
+ * Defensive parse for a sessionStorage value that may have been tampered
+ * with or polluted across versions. Coerces invalid input to 0.
+ *
+ * @param raw - The raw string read from sessionStorage.
+ * @returns
+ *   - A non-negative integer when `raw` parses cleanly.
+ *   - `0` for `NaN`, negatives, or otherwise unparseable input.
+ *
+ * @example
+ *   parseStoredAttempts('1')   // => 1
+ *   parseStoredAttempts('abc') // => 0
+ *   parseStoredAttempts('-5')  // => 0
+ */
+function parseStoredAttempts(raw: string): number {
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}

--- a/src/lib/utils/sanitize-next.ts
+++ b/src/lib/utils/sanitize-next.ts
@@ -1,0 +1,37 @@
+/**
+ * Sanitize a `next` query parameter to prevent open-redirect attacks.
+ *
+ * Used by OAuth callback and silent-refresh route handlers to validate
+ * post-authentication redirect destinations supplied via query string.
+ * Allows only same-origin relative paths starting with `/`. Blocks:
+ *  - protocol-relative URLs (`//evil.com`) — browsers treat as scheme-relative
+ *  - backslash variants (`/\evil.com`) — WHATWG URL Standard normalizes `\`
+ *    to `/` for http/https, so `/\evil.com` parses as `//evil.com`
+ *  - absolute URLs (`https://evil.com`) — fail the leading-`/` check
+ *  - missing input (`null`) — caller's fallback wins
+ *
+ * @param rawNext - Raw `next` query parameter value (or `null` when absent).
+ * @param fallback - Default path returned when sanitization rejects the input.
+ *   Must itself be a safe relative path; not re-validated.
+ * @returns
+ *   - `rawNext` when it is a safe same-origin relative path
+ *   - `fallback` for any rejected, malformed, or null input
+ *
+ * @example
+ *   sanitizeNextPath('/board/abc', '/boards')   // => '/board/abc'
+ *   sanitizeNextPath('//evil.com', '/boards')   // => '/boards'
+ *   sanitizeNextPath('/\\evil.com', '/boards')  // => '/boards'
+ *   sanitizeNextPath('https://x', '/boards')    // => '/boards'
+ *   sanitizeNextPath(null, '/boards')           // => '/boards'
+ */
+export function sanitizeNextPath(
+  rawNext: string | null,
+  fallback: string,
+): string {
+  if (rawNext === null) return fallback
+  return rawNext.startsWith('/') &&
+    !rawNext.startsWith('//') &&
+    !rawNext.includes('\\')
+    ? rawNext
+    : fallback
+}

--- a/src/lib/utils/sanitize-next.ts
+++ b/src/lib/utils/sanitize-next.ts
@@ -1,28 +1,15 @@
 /**
- * Sanitize a `next` query parameter to prevent open-redirect attacks.
+ * Coerce a `next` query parameter to a safe same-origin path. Blocks
+ * protocol-relative (`//evil`), backslash-variant (`/\evil` — WHATWG
+ * normalizes `\` to `/`), and absolute URLs to prevent open redirects.
  *
- * Used by OAuth callback and silent-refresh route handlers to validate
- * post-authentication redirect destinations supplied via query string.
- * Allows only same-origin relative paths starting with `/`. Blocks:
- *  - protocol-relative URLs (`//evil.com`) — browsers treat as scheme-relative
- *  - backslash variants (`/\evil.com`) — WHATWG URL Standard normalizes `\`
- *    to `/` for http/https, so `/\evil.com` parses as `//evil.com`
- *  - absolute URLs (`https://evil.com`) — fail the leading-`/` check
- *  - missing input (`null`) — caller's fallback wins
- *
- * @param rawNext - Raw `next` query parameter value (or `null` when absent).
- * @param fallback - Default path returned when sanitization rejects the input.
- *   Must itself be a safe relative path; not re-validated.
- * @returns
- *   - `rawNext` when it is a safe same-origin relative path
- *   - `fallback` for any rejected, malformed, or null input
+ * @param rawNext - Raw `next` query value (or `null` when absent).
+ * @param fallback - Path returned when input is rejected; assumed safe (not re-validated).
+ * @returns The original path when safe, otherwise the fallback.
  *
  * @example
- *   sanitizeNextPath('/board/abc', '/boards')   // => '/board/abc'
- *   sanitizeNextPath('//evil.com', '/boards')   // => '/boards'
- *   sanitizeNextPath('/\\evil.com', '/boards')  // => '/boards'
- *   sanitizeNextPath('https://x', '/boards')    // => '/boards'
- *   sanitizeNextPath(null, '/boards')           // => '/boards'
+ *   sanitizeNextPath('/board/abc', '/boards') // => '/board/abc'
+ *   sanitizeNextPath('//evil.com', '/boards') // => '/boards'
  */
 export function sanitizeNextPath(
   rawNext: string | null,

--- a/src/tests/unit/app/api/auth/github/refresh.test.ts
+++ b/src/tests/unit/app/api/auth/github/refresh.test.ts
@@ -216,7 +216,7 @@ describe('GET /api/auth/github/refresh', () => {
   })
 
   // ─────────────────────────────────────── Branch C: rate limit
-  it('redirects to /login?error=rate_limited when checkRateLimit denies', async () => {
+  it('redirects to /login?error=rate_limited when checkRateLimit denies (no error message reflected in URL)', async () => {
     vi.mocked(checkRateLimit).mockReturnValue({
       allowed: false,
       error: 'Too many sign-in requests. Please try again later.',
@@ -227,7 +227,9 @@ describe('GET /api/auth/github/refresh', () => {
 
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('/login?error=rate_limited')
-    expect(location).toContain('message=')
+    // Raw rate-limit error text must NOT be reflected back into the redirect
+    // URL — keeps internal error strings out of the open-redirect surface.
+    expect(location).not.toContain('message=')
   })
 
   // ─────────────────────────────────────── Branch D: no Supabase session
@@ -255,7 +257,7 @@ describe('GET /api/auth/github/refresh', () => {
   })
 
   // ─────────────────────────────────────── Branch F: signInWithOAuth error
-  it('redirects to /login?error=oauth_failed when signInWithOAuth returns an error', async () => {
+  it('redirects to /login?error=oauth_failed when signInWithOAuth returns an error (provider message stays server-side)', async () => {
     vi.mocked(createRouteHandlerClient).mockResolvedValue(
       buildSupabaseMock({
         signInWithOAuth: async () => ({
@@ -270,7 +272,13 @@ describe('GET /api/auth/github/refresh', () => {
 
     const location = response.headers.get('location') ?? ''
     expect(location).toContain('/login?error=oauth_failed')
-    expect(location).toContain('message=github%20unreachable')
+    // Provider error message must NOT leak into the redirect URL — Sentry
+    // and the security audit log retain the full detail server-side.
+    expect(location).not.toContain('message=')
+    expect(logSecurityEvent).toHaveBeenCalledWith('login_failure', {
+      error: 'github unreachable',
+      path: 'silent_token_refresh',
+    })
   })
 
   // ─────────────────────────────────────── Branch G: missing data.url

--- a/src/tests/unit/app/api/auth/github/refresh.test.ts
+++ b/src/tests/unit/app/api/auth/github/refresh.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Unit Tests: /api/auth/github/refresh route handler
+ *
+ * Verifies the silent re-auth endpoint behaves correctly across all branches:
+ *
+ *  A. Open-redirect prevention (`next=//evil`, `next=\evil`, scheme-relative)
+ *  B. Attempt cap exceeded (`attempt > MAX_REFRESH_ATTEMPTS`)
+ *  C. Per-IP rate limit hit (reuses `signInWithGitHub` bucket)
+ *  D. No Supabase session — bounce to /login with `next` preserved
+ *  E. Happy path — Supabase returns OAuth URL, response is a 302 to GitHub
+ *  F. signInWithOAuth error — redirect to /login?error=oauth_failed
+ *  G. Missing data.url after signInWithOAuth — same /login?error=oauth_failed
+ *  H. Unexpected exception — redirect to /login?error=unexpected_error
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { checkRateLimit } from '@/lib/rate-limit/check'
+import { logSecurityEvent } from '@/lib/security-events'
+import { createRouteHandlerClient } from '@/lib/supabase/server'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createRouteHandlerClient: vi.fn(),
+}))
+
+vi.mock('@/lib/rate-limit/check', () => ({
+  checkRateLimit: vi.fn().mockReturnValue({ allowed: true }),
+}))
+
+vi.mock('@/lib/security-events', () => ({
+  logSecurityEvent: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createModuleLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}))
+
+const MOCK_USER_ID = '00000000-0000-0000-0000-000000000001'
+const MOCK_GITHUB_OAUTH_URL =
+  'https://github.com/login/oauth/authorize?client_id=test&redirect_uri=...'
+
+/**
+ * Build a Supabase auth-client mock that returns a happy-path session and a
+ * fresh OAuth URL by default. Pass overrides to simulate failure modes.
+ */
+function buildSupabaseMock(
+  overrides: {
+    getUser?: () => Promise<{ data: { user: unknown }; error: unknown }>
+    signInWithOAuth?: () => Promise<{ data: unknown; error: unknown }>
+  } = {},
+) {
+  return {
+    auth: {
+      getUser:
+        overrides.getUser ??
+        (async () => ({
+          data: { user: { id: MOCK_USER_ID } },
+          error: null,
+        })),
+      signInWithOAuth:
+        overrides.signInWithOAuth ??
+        (async () => ({
+          data: { url: MOCK_GITHUB_OAUTH_URL },
+          error: null,
+        })),
+    },
+  }
+}
+
+/**
+ * Build a Request that mimics what Next.js hands the route handler.
+ *
+ * @param search - Query string starting with `?`
+ * @param ip - Value forwarded into the `x-forwarded-for` header
+ */
+function buildRequest(search: string, ip: string = '203.0.113.7'): Request {
+  return new Request(`http://localhost:3008/api/auth/github/refresh${search}`, {
+    headers: { 'x-forwarded-for': ip },
+  })
+}
+
+describe('GET /api/auth/github/refresh', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(checkRateLimit).mockReturnValue({ allowed: true })
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(
+      buildSupabaseMock() as never,
+    )
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ─────────────────────────────────────── Branch E: happy path
+  it('redirects to GitHub OAuth URL on the happy path', async () => {
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe(MOCK_GITHUB_OAUTH_URL)
+    expect(logSecurityEvent).toHaveBeenCalledWith('login_success', {
+      userId: MOCK_USER_ID,
+      path: 'silent_token_refresh',
+    })
+  })
+
+  it('forwards the sanitized `next` param into the callback URL handed to Supabase', async () => {
+    const supabaseMock = buildSupabaseMock()
+    const signInSpy = vi.spyOn(supabaseMock.auth, 'signInWithOAuth')
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(supabaseMock as never)
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    expect(signInSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'github',
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining(
+            '/auth/callback?next=%2Fboard%2Fabc',
+          ),
+          scopes: 'read:user user:email repo',
+        }),
+      }),
+    )
+  })
+
+  // ─────────────────────────────────────── Branch A: open-redirect guard
+  it('coerces protocol-relative `next` (//evil.com) to /boards', async () => {
+    const supabaseMock = buildSupabaseMock()
+    const signInSpy = vi.spyOn(supabaseMock.auth, 'signInWithOAuth')
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(supabaseMock as never)
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    await GET(buildRequest('?next=%2F%2Fevil.com%2Fpwn'))
+
+    expect(signInSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining('/auth/callback?next=%2Fboards'),
+        }),
+      }),
+    )
+  })
+
+  it('coerces backslash-prefixed `next` to /boards', async () => {
+    const supabaseMock = buildSupabaseMock()
+    const signInSpy = vi.spyOn(supabaseMock.auth, 'signInWithOAuth')
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(supabaseMock as never)
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    await GET(buildRequest('?next=%5Cevil'))
+
+    expect(signInSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining('/auth/callback?next=%2Fboards'),
+        }),
+      }),
+    )
+  })
+
+  it('coerces non-relative `next` (https://evil.com) to /boards', async () => {
+    const supabaseMock = buildSupabaseMock()
+    const signInSpy = vi.spyOn(supabaseMock.auth, 'signInWithOAuth')
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(supabaseMock as never)
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    await GET(buildRequest('?next=https%3A%2F%2Fevil.com'))
+
+    expect(signInSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining('/auth/callback?next=%2Fboards'),
+        }),
+      }),
+    )
+  })
+
+  // ─────────────────────────────────────── Branch B: attempt cap
+  it('redirects to /login?error=token_refresh_failed when attempt exceeds the cap', async () => {
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc&attempt=2'))
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toContain(
+      '/login?error=token_refresh_failed',
+    )
+    expect(logSecurityEvent).toHaveBeenCalledWith('login_failure', {
+      error: 'refresh_attempt_cap_exceeded',
+    })
+  })
+
+  it('treats a malformed attempt value as 1 (does not bail)', async () => {
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(
+      buildRequest('?next=%2Fboard%2Fabc&attempt=garbage'),
+    )
+
+    // Should still hit the happy path since malformed clamps to 1.
+    expect(response.headers.get('location')).toBe(MOCK_GITHUB_OAUTH_URL)
+  })
+
+  // ─────────────────────────────────────── Branch C: rate limit
+  it('redirects to /login?error=rate_limited when checkRateLimit denies', async () => {
+    vi.mocked(checkRateLimit).mockReturnValue({
+      allowed: false,
+      error: 'Too many sign-in requests. Please try again later.',
+    })
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('/login?error=rate_limited')
+    expect(location).toContain('message=')
+  })
+
+  // ─────────────────────────────────────── Branch D: no Supabase session
+  it('redirects to /login?next=... when there is no Supabase user', async () => {
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(
+      buildSupabaseMock({
+        getUser: async () => ({
+          data: { user: null },
+          error: { message: 'no session' },
+        }),
+      }) as never,
+    )
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    expect(response.headers.get('location')).toContain(
+      '/login?next=%2Fboard%2Fabc',
+    )
+    // Happy path event must not fire when we bounce to /login.
+    expect(logSecurityEvent).not.toHaveBeenCalledWith(
+      'login_success',
+      expect.anything(),
+    )
+  })
+
+  // ─────────────────────────────────────── Branch F: signInWithOAuth error
+  it('redirects to /login?error=oauth_failed when signInWithOAuth returns an error', async () => {
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(
+      buildSupabaseMock({
+        signInWithOAuth: async () => ({
+          data: { url: null },
+          error: { message: 'github unreachable' },
+        }),
+      }) as never,
+    )
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    const location = response.headers.get('location') ?? ''
+    expect(location).toContain('/login?error=oauth_failed')
+    expect(location).toContain('message=github%20unreachable')
+  })
+
+  // ─────────────────────────────────────── Branch G: missing data.url
+  it('redirects to /login?error=oauth_failed when Supabase returns no redirect URL', async () => {
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(
+      buildSupabaseMock({
+        signInWithOAuth: async () => ({
+          data: { url: null },
+          error: null,
+        }),
+      }) as never,
+    )
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    expect(response.headers.get('location')).toContain(
+      '/login?error=oauth_failed',
+    )
+  })
+
+  // ─────────────────────────────────────── Branch H: unexpected exception
+  it('redirects to /login?error=unexpected_error when an exception bubbles out', async () => {
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(
+      buildSupabaseMock({
+        getUser: async () => {
+          throw new Error('something exploded')
+        },
+      }) as never,
+    )
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    const response = await GET(buildRequest('?next=%2Fboard%2Fabc'))
+
+    expect(response.headers.get('location')).toContain(
+      '/login?error=unexpected_error',
+    )
+  })
+
+  // ─────────────────────────────────────── default-next behavior
+  it('defaults `next` to /boards when not provided', async () => {
+    const supabaseMock = buildSupabaseMock()
+    const signInSpy = vi.spyOn(supabaseMock.auth, 'signInWithOAuth')
+    vi.mocked(createRouteHandlerClient).mockResolvedValue(supabaseMock as never)
+    const { GET } = await import('@/app/api/auth/github/refresh/route')
+
+    await GET(buildRequest(''))
+
+    expect(signInSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          redirectTo: expect.stringContaining('/auth/callback?next=%2Fboards'),
+        }),
+      }),
+    )
+  })
+})

--- a/src/tests/unit/hooks/board/useOrganizationData.test.tsx
+++ b/src/tests/unit/hooks/board/useOrganizationData.test.tsx
@@ -60,7 +60,6 @@ const mockOrgs: GitHubOrganization[] = [
 describe('useOrganizationData', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Default: handler claims redirect ownership (real-world happy path).
     vi.mocked(handleGitHubTokenMissing).mockReturnValue(true)
   })
 
@@ -92,7 +91,7 @@ describe('useOrganizationData', () => {
 
     expect(result.current.currentUser).toEqual(mockUser)
     expect(result.current.organizations).toEqual(mockOrgs)
-    // octocat (id 11) is dropped because it matches the current user login.
+    // The hook strips orgs whose login matches the current user.
     expect(result.current.filteredOrganizations).toEqual([mockOrgs[0]])
     expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
     expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
@@ -116,7 +115,6 @@ describe('useOrganizationData', () => {
       expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
     })
 
-    // Hook returned early — no state was applied, no counter reset fired.
     expect(result.current.currentUser).toBeNull()
     expect(result.current.organizations).toEqual([])
     expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
@@ -138,7 +136,9 @@ describe('useOrganizationData', () => {
     await waitFor(() => {
       expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
     })
-    // Even partial token-missing aborts the state writes — we wait for refresh.
+    // Partial token-missing must still suppress the counter reset — once the
+    // refresh redirect kicks in, treating the user fetch as "success" would
+    // wipe the attempt cap and risk an infinite loop.
     expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
   })
 
@@ -160,10 +160,10 @@ describe('useOrganizationData', () => {
       expect(result.current.isLoadingOrgs).toBe(false)
     })
 
-    // User came back, orgs did not — UI should still render the user data.
     expect(result.current.currentUser).toEqual(mockUser)
     expect(result.current.organizations).toEqual([])
-    // Counter resets because the user fetch confirmed the token is alive.
+    // Counter resets because the successful user fetch proves the token is
+    // alive even though the orgs call still reports it missing.
     expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
   })
 

--- a/src/tests/unit/hooks/board/useOrganizationData.test.tsx
+++ b/src/tests/unit/hooks/board/useOrganizationData.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Unit Tests: useOrganizationData Hook
+ *
+ * Verifies the organization data fetcher reacts correctly to:
+ *  - Combobox open transition (idle → fetch → loaded)
+ *  - GITHUB_TOKEN_MISSING from either Server Action → silent refresh redirect
+ *  - Iframe fall-through (handler returns false) → keep partial successful data
+ *  - Successful response → reset attempt counter via clearGitHubRefreshAttempts
+ *  - filteredOrganizations strips the current user from the list
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { useOrganizationData } from '@/hooks/board/useOrganizationData'
+import {
+  getAuthenticatedUser,
+  getAuthenticatedUserOrganizations,
+  type GitHubUser,
+  type GitHubOrganization,
+} from '@/lib/actions/github'
+import {
+  clearGitHubRefreshAttempts,
+  handleGitHubTokenMissing,
+} from '@/lib/utils/handle-github-token-missing'
+
+vi.mock('@/lib/actions/github', () => ({
+  getAuthenticatedUser: vi.fn(),
+  getAuthenticatedUserOrganizations: vi.fn(),
+}))
+
+vi.mock('@/lib/utils/handle-github-token-missing', () => ({
+  handleGitHubTokenMissing: vi.fn(),
+  clearGitHubRefreshAttempts: vi.fn(),
+}))
+
+const mockUser: GitHubUser = {
+  id: 1,
+  login: 'octocat',
+  avatar_url: 'https://example.com/octocat.png',
+  name: 'The Octocat',
+  type: 'User',
+}
+
+const mockOrgs: GitHubOrganization[] = [
+  {
+    id: 10,
+    login: 'laststance',
+    avatar_url: 'https://example.com/laststance.png',
+    description: 'org',
+  },
+  {
+    id: 11,
+    login: 'octocat',
+    avatar_url: 'https://example.com/octocat.png',
+    description: 'self-as-org',
+  },
+]
+
+describe('useOrganizationData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Default: handler claims redirect ownership (real-world happy path).
+    vi.mocked(handleGitHubTokenMissing).mockReturnValue(true)
+  })
+
+  it('does nothing while combobox is closed', () => {
+    const { result } = renderHook(() => useOrganizationData(false))
+
+    expect(result.current.currentUser).toBeNull()
+    expect(result.current.organizations).toEqual([])
+    expect(result.current.isLoadingOrgs).toBe(false)
+    expect(getAuthenticatedUser).not.toHaveBeenCalled()
+    expect(getAuthenticatedUserOrganizations).not.toHaveBeenCalled()
+  })
+
+  it('fetches user + orgs on open and resets the refresh counter on success', async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue({
+      success: true,
+      data: mockUser,
+    })
+    vi.mocked(getAuthenticatedUserOrganizations).mockResolvedValue({
+      success: true,
+      data: mockOrgs,
+    })
+
+    const { result } = renderHook(() => useOrganizationData(true))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingOrgs).toBe(false)
+    })
+
+    expect(result.current.currentUser).toEqual(mockUser)
+    expect(result.current.organizations).toEqual(mockOrgs)
+    // octocat (id 11) is dropped because it matches the current user login.
+    expect(result.current.filteredOrganizations).toEqual([mockOrgs[0]])
+    expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
+    expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
+  })
+
+  it('triggers silent refresh exactly once when both calls report GITHUB_TOKEN_MISSING', async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+    vi.mocked(getAuthenticatedUserOrganizations).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    const { result } = renderHook(() => useOrganizationData(true))
+
+    await waitFor(() => {
+      expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
+    })
+
+    // Hook returned early — no state was applied, no counter reset fired.
+    expect(result.current.currentUser).toBeNull()
+    expect(result.current.organizations).toEqual([])
+    expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
+  })
+
+  it('triggers silent refresh when only one of the two calls reports GITHUB_TOKEN_MISSING', async () => {
+    vi.mocked(getAuthenticatedUser).mockResolvedValue({
+      success: true,
+      data: mockUser,
+    })
+    vi.mocked(getAuthenticatedUserOrganizations).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    renderHook(() => useOrganizationData(true))
+
+    await waitFor(() => {
+      expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
+    })
+    // Even partial token-missing aborts the state writes — we wait for refresh.
+    expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
+  })
+
+  it('falls through to populate partial data when handler reports iframe context', async () => {
+    vi.mocked(handleGitHubTokenMissing).mockReturnValue(false)
+    vi.mocked(getAuthenticatedUser).mockResolvedValue({
+      success: true,
+      data: mockUser,
+    })
+    vi.mocked(getAuthenticatedUserOrganizations).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    const { result } = renderHook(() => useOrganizationData(true))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingOrgs).toBe(false)
+    })
+
+    // User came back, orgs did not — UI should still render the user data.
+    expect(result.current.currentUser).toEqual(mockUser)
+    expect(result.current.organizations).toEqual([])
+    // Counter resets because the user fetch confirmed the token is alive.
+    expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not crash when both Server Actions throw mid-fetch', async () => {
+    vi.mocked(getAuthenticatedUser).mockRejectedValue(new Error('network'))
+    vi.mocked(getAuthenticatedUserOrganizations).mockRejectedValue(
+      new Error('network'),
+    )
+
+    const { result } = renderHook(() => useOrganizationData(true))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingOrgs).toBe(false)
+    })
+
+    expect(result.current.currentUser).toBeNull()
+    expect(result.current.organizations).toEqual([])
+    expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
+    expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/unit/hooks/board/useRepositoryData.test.tsx
+++ b/src/tests/unit/hooks/board/useRepositoryData.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Unit Tests: useRepositoryData Hook
+ *
+ * Verifies the repository fetcher reacts correctly to:
+ *  - Idle state while combobox is closed or orgs still loading
+ *  - GITHUB_TOKEN_MISSING from the initial /user/repos call → silent refresh
+ *  - GITHUB_TOKEN_MISSING from any of the parallel /orgs/{login}/repos calls
+ *    → silent refresh
+ *  - Iframe fall-through (handler returns false) for the org-batch case
+ *    → keep already-fetched user repos and surface a reposError string
+ *  - Successful path → merge org repos by id, reset attempt counter
+ *  - Generic Server Action error → set reposError, do not redirect
+ */
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { useRepositoryData } from '@/hooks/board/useRepositoryData'
+import {
+  getAuthenticatedUserRepositories,
+  getOrganizationRepositories,
+  type GitHubRepository,
+  type GitHubOrganization,
+} from '@/lib/actions/github'
+import {
+  clearGitHubRefreshAttempts,
+  handleGitHubTokenMissing,
+} from '@/lib/utils/handle-github-token-missing'
+
+vi.mock('@/lib/actions/github', () => ({
+  getAuthenticatedUserRepositories: vi.fn(),
+  getOrganizationRepositories: vi.fn(),
+}))
+
+vi.mock('@/lib/utils/handle-github-token-missing', () => ({
+  handleGitHubTokenMissing: vi.fn(),
+  clearGitHubRefreshAttempts: vi.fn(),
+}))
+
+const buildRepo = (
+  overrides: Partial<GitHubRepository> = {},
+): GitHubRepository => ({
+  id: 1,
+  node_id: 'node-1',
+  name: 'repo-1',
+  full_name: 'octocat/repo-1',
+  owner: { login: 'octocat', avatar_url: 'https://example.com/o.png' },
+  description: null,
+  html_url: 'https://github.com/octocat/repo-1',
+  homepage: null,
+  stargazers_count: 0,
+  watchers_count: 0,
+  language: null,
+  topics: [],
+  visibility: 'public',
+  updated_at: '2026-04-29T00:00:00Z',
+  created_at: '2026-04-29T00:00:00Z',
+  ...overrides,
+})
+
+const userRepo = buildRepo({ id: 1, name: 'user-repo' })
+const sharedRepo = buildRepo({ id: 2, name: 'shared-repo' })
+const orgOnlyRepo = buildRepo({ id: 3, name: 'org-only' })
+
+const orgs: GitHubOrganization[] = [
+  {
+    id: 100,
+    login: 'laststance',
+    avatar_url: 'https://example.com/laststance.png',
+    description: null,
+  },
+]
+
+describe('useRepositoryData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(handleGitHubTokenMissing).mockReturnValue(true)
+  })
+
+  it('does not fetch while orgs are still loading', () => {
+    renderHook(() => useRepositoryData(true, orgs, true))
+    expect(getAuthenticatedUserRepositories).not.toHaveBeenCalled()
+    expect(getOrganizationRepositories).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch while combobox is closed', () => {
+    renderHook(() => useRepositoryData(false, orgs, false))
+    expect(getAuthenticatedUserRepositories).not.toHaveBeenCalled()
+    expect(getOrganizationRepositories).not.toHaveBeenCalled()
+  })
+
+  it('merges user + org repos and dedupes by id on the success path', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: true,
+      data: [userRepo, sharedRepo],
+    })
+    vi.mocked(getOrganizationRepositories).mockResolvedValue({
+      success: true,
+      data: [sharedRepo, orgOnlyRepo],
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingRepos).toBe(false)
+    })
+
+    expect(result.current.userRepos.map((r) => r.id)).toEqual([1, 2, 3])
+    expect(result.current.reposError).toBeNull()
+    expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
+    expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
+  })
+
+  it('triggers silent refresh when the initial /user/repos call reports GITHUB_TOKEN_MISSING', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
+    })
+
+    // Org repos are never queried because the hook returned early.
+    expect(getOrganizationRepositories).not.toHaveBeenCalled()
+    expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
+    // No reposError set — refresh redirect supersedes the error UI.
+    expect(result.current.reposError).toBeNull()
+    expect(result.current.userRepos).toEqual([])
+  })
+
+  it('surfaces reposError without redirect for a non-token-missing initial failure', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: false,
+      error: 'Network error',
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingRepos).toBe(false)
+    })
+
+    expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
+    expect(result.current.reposError).toBe('Network error')
+    expect(result.current.userRepos).toEqual([])
+  })
+
+  it('triggers silent refresh when an org repo call reports GITHUB_TOKEN_MISSING mid-batch', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: true,
+      data: [userRepo],
+    })
+    vi.mocked(getOrganizationRepositories).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
+    })
+
+    // Counter was reset by the successful initial call before the org batch
+    // discovered the stale token — that's intentional.
+    expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
+    // No partial data written because the redirect handler claimed ownership.
+    expect(result.current.userRepos).toEqual([])
+    expect(result.current.reposError).toBeNull()
+  })
+
+  it('keeps user repos and surfaces an auth error when iframe fall-through hits the org batch', async () => {
+    vi.mocked(handleGitHubTokenMissing).mockReturnValue(false)
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: true,
+      data: [userRepo],
+    })
+    vi.mocked(getOrganizationRepositories).mockResolvedValue({
+      success: false,
+      error: 'GitHub authentication required',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingRepos).toBe(false)
+    })
+
+    expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
+    expect(result.current.userRepos).toEqual([userRepo])
+    expect(result.current.reposError).toBe(
+      'GitHub authentication required. Please sign in again.',
+    )
+  })
+
+  it('skips org fetch entirely when there are no organizations', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockResolvedValue({
+      success: true,
+      data: [userRepo],
+    })
+
+    const { result } = renderHook(() => useRepositoryData(true, [], false))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingRepos).toBe(false)
+    })
+
+    expect(getOrganizationRepositories).not.toHaveBeenCalled()
+    expect(result.current.userRepos).toEqual([userRepo])
+    expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
+  })
+
+  it('captures thrown errors as reposError without crashing', async () => {
+    vi.mocked(getAuthenticatedUserRepositories).mockRejectedValue(
+      new Error('boom'),
+    )
+
+    const { result } = renderHook(() => useRepositoryData(true, orgs, false))
+
+    await waitFor(() => {
+      expect(result.current.isLoadingRepos).toBe(false)
+    })
+
+    expect(result.current.reposError).toBe('boom')
+    expect(result.current.userRepos).toEqual([])
+    expect(handleGitHubTokenMissing).not.toHaveBeenCalled()
+  })
+})

--- a/src/tests/unit/hooks/board/useRepositoryData.test.tsx
+++ b/src/tests/unit/hooks/board/useRepositoryData.test.tsx
@@ -124,10 +124,10 @@ describe('useRepositoryData', () => {
       expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
     })
 
-    // Org repos are never queried because the hook returned early.
     expect(getOrganizationRepositories).not.toHaveBeenCalled()
     expect(clearGitHubRefreshAttempts).not.toHaveBeenCalled()
-    // No reposError set — refresh redirect supersedes the error UI.
+    // Refresh redirect owns the UX — surfacing reposError on top would flash
+    // an error toast right before the page navigates away.
     expect(result.current.reposError).toBeNull()
     expect(result.current.userRepos).toEqual([])
   })
@@ -166,10 +166,10 @@ describe('useRepositoryData', () => {
       expect(handleGitHubTokenMissing).toHaveBeenCalledTimes(1)
     })
 
-    // Counter was reset by the successful initial call before the org batch
-    // discovered the stale token — that's intentional.
+    // Counter reset is intentional: the initial /user/repos call proved the
+    // token was alive at that moment, so the loop-protection counter SHOULD
+    // forget any earlier failure before the org batch discovers staleness.
     expect(clearGitHubRefreshAttempts).toHaveBeenCalledTimes(1)
-    // No partial data written because the redirect handler claimed ownership.
     expect(result.current.userRepos).toEqual([])
     expect(result.current.reposError).toBeNull()
   })

--- a/src/tests/unit/lib/actions/github-error-code.test.ts
+++ b/src/tests/unit/lib/actions/github-error-code.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit Tests: GitHub Server Action Error Codes
+ *
+ * Verifies that the four token-gated GitHub Server Actions return a
+ * structured `ActionResult` with `errorCode: 'GITHUB_TOKEN_MISSING'`
+ * when the provider_token cookie is absent. The client-side hook in
+ * `src/lib/utils/handle-github-token-missing.ts` keys off this code to
+ * trigger silent re-auth instead of surfacing the error to the user.
+ *
+ * Covered actions:
+ *  - getAuthenticatedUser
+ *  - getAuthenticatedUserRepositories
+ *  - getAuthenticatedUserOrganizations
+ *  - getOrganizationRepositories
+ */
+
+import { cookies } from 'next/headers'
+import type * as NextHeaders from 'next/headers'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('next/headers', async () => {
+  const actual = await vi.importActual<typeof NextHeaders>('next/headers')
+  return {
+    ...actual,
+    cookies: vi.fn(),
+    headers: vi.fn().mockResolvedValue({
+      get: vi.fn().mockReturnValue('127.0.0.1'),
+    }),
+  }
+})
+
+describe('GitHub Server Actions: errorCode=GITHUB_TOKEN_MISSING', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    // Force the production code path so hasGitHubToken actually inspects
+    // the cookie store (test mode short-circuits to true).
+    process.env.NEXT_PUBLIC_ENABLE_MSW_MOCK = 'false'
+    process.env.APP_ENV = 'production'
+    process.env.NEXT_PUBLIC_SUPABASE_URL =
+      'https://jqtxjzdxczqwsrvevmyk.supabase.co'
+
+    const cookieStoreMissingToken = {
+      get: vi.fn().mockReturnValue(undefined),
+    }
+    vi.mocked(cookies).mockResolvedValue(cookieStoreMissingToken as never)
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.clearAllMocks()
+  })
+
+  it('getAuthenticatedUser returns errorCode when cookie is absent', async () => {
+    const { getAuthenticatedUser } = await import('@/lib/actions/github')
+
+    const result = await getAuthenticatedUser()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'GitHub token not found. Please sign in again.',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+  })
+
+  it('getAuthenticatedUserRepositories returns errorCode when cookie is absent', async () => {
+    const { getAuthenticatedUserRepositories } =
+      await import('@/lib/actions/github')
+
+    const result = await getAuthenticatedUserRepositories({ fetchAll: true })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'GitHub token not found. Please sign in again.',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+  })
+
+  it('getAuthenticatedUserOrganizations returns errorCode when cookie is absent', async () => {
+    const { getAuthenticatedUserOrganizations } =
+      await import('@/lib/actions/github')
+
+    const result = await getAuthenticatedUserOrganizations()
+
+    expect(result).toEqual({
+      success: false,
+      error: 'GitHub token not found. Please sign in again.',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+  })
+
+  it('getOrganizationRepositories returns errorCode when cookie is absent', async () => {
+    const { getOrganizationRepositories } = await import('@/lib/actions/github')
+
+    const result = await getOrganizationRepositories('laststance', {
+      fetchAll: true,
+    })
+
+    expect(result).toEqual({
+      success: false,
+      error: 'GitHub token not found. Please sign in again.',
+      errorCode: 'GITHUB_TOKEN_MISSING',
+    })
+  })
+})

--- a/src/tests/unit/lib/axios-github.test.ts
+++ b/src/tests/unit/lib/axios-github.test.ts
@@ -4,15 +4,32 @@
  * Tests for GitHub API Axios instance and token utilities:
  * - createGitHubAxios (axios instance creation)
  * - hasGitHubToken (token availability check)
+ * - 401 response interceptor (clears stale cookie via deleteGitHubTokenCookie)
  */
 
+import axios from 'axios'
 import { cookies } from 'next/headers'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { deleteGitHubTokenCookie } from '@/lib/constants/cookies'
+import type * as CookiesModule from '@/lib/constants/cookies'
 
 // Mock next/headers before importing the module
 vi.mock('next/headers', () => ({
   cookies: vi.fn(),
 }))
+
+// Mock the cookie helper so we can spy on the delete call without touching
+// the real Next cookie store (which is not available in this test runtime).
+vi.mock('@/lib/constants/cookies', async () => {
+  const actual = await vi.importActual<typeof CookiesModule>(
+    '@/lib/constants/cookies',
+  )
+  return {
+    ...actual,
+    deleteGitHubTokenCookie: vi.fn().mockResolvedValue(undefined),
+  }
+})
 
 describe('axios-github', () => {
   const originalEnv = process.env
@@ -230,6 +247,97 @@ describe('axios-github', () => {
 
         expect(result).toBe(false)
       })
+    })
+  })
+
+  describe('response interceptor: 401 cookie cleanup', () => {
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_ENABLE_MSW_MOCK = 'false'
+      process.env.APP_ENV = 'production'
+      vi.mocked(deleteGitHubTokenCookie).mockClear()
+    })
+
+    /**
+     * Helper: Build a structurally-valid AxiosError so the interceptor's
+     * `axios.isAxiosError(error)` guard passes.
+     *
+     * Constructing via `new axios.AxiosError(...)` guarantees the prototype
+     * chain matches what `isAxiosError` checks for — a plain `{ isAxiosError:
+     * true, ... }` object would fail that check.
+     */
+    function makeAxiosError(status: number) {
+      return new axios.AxiosError(
+        'Request failed',
+        'ERR_BAD_REQUEST',
+        undefined,
+        undefined,
+        {
+          status,
+          data: {},
+          statusText: 'Error',
+          headers: {},
+          config: { headers: {} as never },
+        } as never,
+      )
+    }
+
+    it('clears the GitHub cookie when the API responds 401', async () => {
+      vi.resetModules()
+      const { createGitHubAxios } = await import('@/lib/axios-github')
+      const instance = createGitHubAxios()
+
+      const rejectedHandler = (instance.interceptors.response as any)
+        .handlers[0].rejected
+
+      await expect(rejectedHandler(makeAxiosError(401))).rejects.toBeDefined()
+
+      expect(deleteGitHubTokenCookie).toHaveBeenCalledTimes(1)
+    })
+
+    it('does NOT clear the cookie on non-401 errors (403, 404, 500)', async () => {
+      vi.resetModules()
+      const { createGitHubAxios } = await import('@/lib/axios-github')
+      const instance = createGitHubAxios()
+
+      const rejectedHandler = (instance.interceptors.response as any)
+        .handlers[0].rejected
+
+      for (const status of [403, 404, 500]) {
+        await expect(
+          rejectedHandler(makeAxiosError(status)),
+        ).rejects.toBeDefined()
+      }
+
+      expect(deleteGitHubTokenCookie).not.toHaveBeenCalled()
+    })
+
+    it('does NOT clear the cookie on non-axios errors (network drop, timeout)', async () => {
+      vi.resetModules()
+      const { createGitHubAxios } = await import('@/lib/axios-github')
+      const instance = createGitHubAxios()
+
+      const rejectedHandler = (instance.interceptors.response as any)
+        .handlers[0].rejected
+
+      const plainError = new Error('Network down')
+      await expect(rejectedHandler(plainError)).rejects.toBe(plainError)
+
+      expect(deleteGitHubTokenCookie).not.toHaveBeenCalled()
+    })
+
+    it('still rejects the original error when cookie deletion throws', async () => {
+      vi.mocked(deleteGitHubTokenCookie).mockRejectedValueOnce(
+        new Error('cookie store unavailable in static generation'),
+      )
+      vi.resetModules()
+      const { createGitHubAxios } = await import('@/lib/axios-github')
+      const instance = createGitHubAxios()
+
+      const rejectedHandler = (instance.interceptors.response as any)
+        .handlers[0].rejected
+
+      const original = makeAxiosError(401)
+      await expect(rejectedHandler(original)).rejects.toBe(original)
     })
   })
 })

--- a/src/tests/unit/lib/constants/cookies.test.ts
+++ b/src/tests/unit/lib/constants/cookies.test.ts
@@ -1,12 +1,23 @@
 /**
  * Unit Tests: Cookie Constants
  *
- * Tests for environment-specific cookie name generation
+ * Tests for environment-specific cookie name generation,
+ * the 30-day maxAge constant, and the set/delete cookie helpers.
  */
 
+import { cookies } from 'next/headers'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { getGitHubTokenCookieName } from '@/lib/constants/cookies'
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(),
+}))
+
+import {
+  getGitHubTokenCookieName,
+  GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS,
+  setGitHubTokenCookie,
+  deleteGitHubTokenCookie,
+} from '@/lib/constants/cookies'
 
 describe('getGitHubTokenCookieName', () => {
   const originalEnv = process.env
@@ -77,5 +88,102 @@ describe('getGitHubTokenCookieName', () => {
     const cookieName = getGitHubTokenCookieName()
 
     expect(cookieName).toBe('gh_token_abc')
+  })
+})
+
+describe('GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS', () => {
+  it('should equal 30 days in seconds (regression guard for the 8h bug)', () => {
+    // The original bug used `60 * 60 * 8` (8 hours) which caused users to lose
+    // GitHub access after a workday. 30 days matches Supabase refresh_token TTL.
+    expect(GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS).toBe(30 * 24 * 60 * 60)
+    expect(GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS).toBe(2_592_000)
+  })
+})
+
+describe('setGitHubTokenCookie', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.NEXT_PUBLIC_SUPABASE_URL =
+      'https://jqtxjzdxczqwsrvevmyk.supabase.co'
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.clearAllMocks()
+  })
+
+  it('should call cookieStore.set with the env-specific name and 30d maxAge', async () => {
+    const setSpy = vi.fn()
+    vi.mocked(cookies).mockResolvedValue({ set: setSpy } as never)
+
+    await setGitHubTokenCookie('test-provider-token')
+
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    expect(setSpy).toHaveBeenCalledWith(
+      'gh_token_jqtxjzdx',
+      'test-provider-token',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'lax',
+        maxAge: GITHUB_TOKEN_COOKIE_MAX_AGE_SECONDS,
+        path: '/',
+      }),
+    )
+  })
+
+  it('should set secure=false outside production', async () => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV =
+      'development'
+    const setSpy = vi.fn()
+    vi.mocked(cookies).mockResolvedValue({ set: setSpy } as never)
+
+    await setGitHubTokenCookie('token')
+
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ secure: false }),
+    )
+  })
+
+  it('should set secure=true in production', async () => {
+    ;(process.env as Record<string, string | undefined>).NODE_ENV = 'production'
+    const setSpy = vi.fn()
+    vi.mocked(cookies).mockResolvedValue({ set: setSpy } as never)
+
+    await setGitHubTokenCookie('token')
+
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ secure: true }),
+    )
+  })
+})
+
+describe('deleteGitHubTokenCookie', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }
+    process.env.NEXT_PUBLIC_SUPABASE_URL =
+      'https://jqtxjzdxczqwsrvevmyk.supabase.co'
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+    vi.clearAllMocks()
+  })
+
+  it('should call cookieStore.delete with the env-specific name', async () => {
+    const deleteSpy = vi.fn()
+    vi.mocked(cookies).mockResolvedValue({ delete: deleteSpy } as never)
+
+    await deleteGitHubTokenCookie()
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1)
+    expect(deleteSpy).toHaveBeenCalledWith('gh_token_jqtxjzdx')
   })
 })

--- a/src/tests/unit/lib/utils/handle-github-token-missing.test.ts
+++ b/src/tests/unit/lib/utils/handle-github-token-missing.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit Tests: handle-github-token-missing
+ *
+ * Verifies the silent re-auth helper behaves correctly under:
+ *  - First-time call (no `attempt` query param)
+ *  - Module-level lock (parallel hooks fire only one redirect)
+ *  - sessionStorage counter increment across redirects
+ *  - Counter reset via `clearGitHubRefreshAttempts`
+ *  - Tampered storage values (parsed defensively)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const STORAGE_KEY = 'gh_refresh_attempts'
+
+describe('handleGitHubTokenMissing', () => {
+  // We re-import the module per test so the module-level `isRefreshInFlight`
+  // lock resets, mirroring real-world behavior where the page reloads after
+  // a redirect.
+  let originalLocation: Location
+
+  beforeEach(() => {
+    vi.resetModules()
+    window.sessionStorage.clear()
+    originalLocation = window.location
+    // happy-dom assigns to window.location.href triggering JSDOM-style nav.
+    // Replace with a plain object so we can assert on the value without the
+    // env trying to actually navigate.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: { ...originalLocation, href: 'http://localhost/board/abc' },
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: originalLocation,
+    })
+  })
+
+  it('redirects to /api/auth/github/refresh with `next` and no attempt param on first call', async () => {
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    const wasHandled = handleGitHubTokenMissing('/board/abc')
+
+    expect(wasHandled).toBe(true)
+    expect(window.location.href).toBe(
+      '/api/auth/github/refresh?next=%2Fboard%2Fabc',
+    )
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('emits ?attempt=2 on the second call (after sessionStorage already records 1)', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, '1')
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    handleGitHubTokenMissing('/board/abc')
+
+    expect(window.location.href).toBe(
+      '/api/auth/github/refresh?next=%2Fboard%2Fabc&attempt=2',
+    )
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('2')
+  })
+
+  it('only redirects once when called many times in the same JS tick (module lock)', async () => {
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    const firstResult = handleGitHubTokenMissing('/board/abc')
+    const firstHref = window.location.href
+
+    // Simulate 4 sibling hooks all firing in parallel (one initial + 3 dup).
+    const secondResult = handleGitHubTokenMissing('/board/abc')
+    const thirdResult = handleGitHubTokenMissing('/board/abc')
+    const fourthResult = handleGitHubTokenMissing('/board/abc')
+
+    // All siblings should report "handled" so the caller short-circuits its
+    // own error UI even though only one redirect actually fired.
+    expect(firstResult).toBe(true)
+    expect(secondResult).toBe(true)
+    expect(thirdResult).toBe(true)
+    expect(fourthResult).toBe(true)
+    expect(window.location.href).toBe(firstHref)
+    // Counter should only have been bumped once.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('coerces tampered sessionStorage values (e.g. "abc") back to a fresh first attempt', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, 'not-a-number')
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    handleGitHubTokenMissing('/board/abc')
+
+    expect(window.location.href).toBe(
+      '/api/auth/github/refresh?next=%2Fboard%2Fabc',
+    )
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('coerces negative sessionStorage values back to a fresh first attempt', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, '-5')
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    handleGitHubTokenMissing('/board/abc')
+
+    expect(window.location.href).toBe(
+      '/api/auth/github/refresh?next=%2Fboard%2Fabc',
+    )
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBe('1')
+  })
+
+  it('encodes the next path so query params survive intact', async () => {
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    handleGitHubTokenMissing('/board/abc?tab=cards&filter=open')
+
+    expect(window.location.href).toBe(
+      '/api/auth/github/refresh?next=%2Fboard%2Fabc%3Ftab%3Dcards%26filter%3Dopen',
+    )
+  })
+
+  it('returns false and does NOT navigate when running inside an iframe (Storybook test orchestrator, embedded views)', async () => {
+    // happy-dom defaults `window.parent === window`. Override it so the
+    // helper detects an embedded context and bails out cleanly.
+    const fakeParent = { ...window } as Window
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      get: () => fakeParent,
+    })
+    const initialHref = window.location.href
+
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    const wasHandled = handleGitHubTokenMissing('/board/abc')
+
+    expect(wasHandled).toBe(false)
+    expect(window.location.href).toBe(initialHref)
+    // Counter is untouched so the next non-iframe call still starts at 1.
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+
+    Object.defineProperty(window, 'parent', {
+      configurable: true,
+      get: () => window,
+    })
+  })
+
+  it('returns false in SSR contexts where window is undefined', async () => {
+    const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'window',
+    )
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    })
+
+    const { handleGitHubTokenMissing } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    const wasHandled = handleGitHubTokenMissing('/board/abc')
+
+    expect(wasHandled).toBe(false)
+
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, 'window', originalWindowDescriptor)
+    }
+  })
+})
+
+describe('clearGitHubRefreshAttempts', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    window.sessionStorage.clear()
+  })
+
+  it('removes the counter from sessionStorage', async () => {
+    window.sessionStorage.setItem(STORAGE_KEY, '1')
+    const { clearGitHubRefreshAttempts } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    clearGitHubRefreshAttempts()
+
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  it('is a no-op when the counter is already absent', async () => {
+    const { clearGitHubRefreshAttempts } =
+      await import('@/lib/utils/handle-github-token-missing')
+
+    expect(() => clearGitHubRefreshAttempts()).not.toThrow()
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

When the GitHub provider_token cookie expires (cookie TTL was 8h, now 30d) but the Supabase session is still valid (~30d), users hit "GitHub token not found. Please sign in again." This PR makes the recovery silent: server actions return `errorCode: 'GITHUB_TOKEN_MISSING'`, the client redirects to `/api/auth/github/refresh?next=<path>`, and the user lands back on the original page with a fresh token.

- Closes the bookmark-after-8-hours bug (user returns 1+ days later via `/board/<id>` bookmark)
- Cookie TTL aligned with Supabase refresh token (30d)
- Defense in depth: client `sessionStorage` attempt counter + server `attempt` query cap + IP rate limit + open-redirect-safe `next`

## What changed

- **New route**: `src/app/api/auth/github/refresh/route.ts` — re-runs `signInWithOAuth` from a logged-in session, redirects via `/auth/callback?next=<path>`
- **New utilities**: `sanitizeNextPath` (open-redirect guard), `getForwardedClientIp` (consolidated x-forwarded-for parser), `handleGitHubTokenMissing` (client redirect helper with idempotency lock)
- **`ActionResult<T>`**: optional `errorCode: 'GITHUB_TOKEN_MISSING'` discriminant on the failure variant; emitted by `getAuthenticatedUser`, `getAuthenticatedUserOrganizations`, `getAuthenticatedUserRepositories`, `getOrganizationRepositories`
- **Cookie helpers**: `setGitHubTokenCookie` / `deleteGitHubTokenCookie` consolidate cookie writes; 30-day TTL constant with security JSDoc
- **Hook updates**: `useOrganizationData`, `useRepositoryData` consume `errorCode` and call the helper

3 commits split for bisectability:
- `344753c feat(auth): add silent GitHub token refresh on expired provider token`
- `cbff8f2 refactor(auth): dedupe x-forwarded-for parsing and trim doc bloat`
- `0fef197 chore(release): v0.3.0 — silent GitHub token refresh`
- `fd30e24 chore: add gstack skill routing rules to CLAUDE.md` (unrelated tooling chore)

## Test plan

All quality gates green pre-merge:

- [x] `pnpm test` — 96 files / 1346 tests pass (17.15s)
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — clean (Next.js 16 production build)
- [x] New unit tests: `refresh.test.ts` (10 cases / 8 branches), `useOrganizationData.test.tsx` (6 cases), `useRepositoryData.test.tsx` (8 cases), `handle-github-token-missing.test.ts` (9 cases), `github-error-code.test.ts` (4 actions × 1 case), `axios-github.test.ts` (4 cases for 401 interceptor), `cookies.test.ts` (TTL regression guard + secure flag prod/dev)
- [x] New E2E spec: `e2e/logged-in/silent-token-refresh.spec.ts` (attempt-cap bail-out under real Next runtime; happy-path E2E skipped per architectural reason in spec, unit tests compensate)
- [x] Manual smoke (production-equivalent flow not run; rely on tests + reviews)

## Reviews run pre-merge (gstack `/ship`)

| Review | Verdict |
|---|---|
| Test coverage audit | PASS |
| Plan completion vs. eng-review plan | PASS |
| Backend security | WARN (3 P2 — see TODOS.md) |
| Modern React (hook patterns) | PASS w/ 1 WARN |
| Code quality / DRY | PASS |
| Claude adversarial | WARN (5 P2 — see TODOS.md) |
| Codex adversarial | WARN (4 P2 — see TODOS.md) |

**No P1 ship-blockers found.** All P2 findings synthesized into [`TODOS.md`](./TODOS.md) for follow-up:
- Preserve `?query` and `#hash` on refresh redirect
- Multi-tab PKCE collision handling
- 401 interceptor races freshly-set cookie
- Counter not bumped on cap-exceeded redirect
- `x-forwarded-for` first-IP spoofing on Vercel (rate-limit only)
- Server `attempt` cap bypassed when `sessionStorage` unavailable
- Error-message reflection in `/login?message=...`
- Race on rapid combobox open/close (no AbortController)
- Add dedicated unit tests for `sanitizeNextPath` + `getForwardedClientIp`
- 30-day cookie TTL risk re-confirm + scope narrowing

## Plan reference

Eng-review plan that drove this work: `~/.gstack/projects/laststance-gitbox/raphtalia-main-eng-review-plan-2026-04-29T133205.md` (D1–D19 decisions all reflected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: Version 0.3.0

* **New Features**
  * Added silent GitHub authentication refresh to prevent users from being unexpectedly logged out when tokens expire.
  * Implemented automatic redirect to original location after successful re-authentication.

* **Bug Fixes**
  * Fixed "bookmark-after-8-hours" flow where users were forced to sign in again instead of silently refreshing authentication.

* **Documentation**
  * Added comprehensive changelog and project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->