### PR TITLE
[codex] Resolve codebase litter audit issues

### DIFF
--- a/e2e/logged-in/board-dnd.spec.ts
+++ b/e2e/logged-in/board-dnd.spec.ts
@@ -73,12 +73,6 @@ test.describe('Board DnD Reordering', () => {
   })
 
   test('should swap two boards via CDP drag @slow', async ({ page }) => {
-    // CDP drag can be flaky — soft skip guard
-    test.skip(
-      !!process.env.CI && process.env.SKIP_DND_TESTS === 'true',
-      'CDP DnD tests can be flaky in CI',
-    )
-
     await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
@@ -143,12 +137,6 @@ test.describe('Board DnD Reordering', () => {
   test('should persist board positions to database after drag @slow', async ({
     page,
   }) => {
-    // CDP drag can be flaky — soft skip guard
-    test.skip(
-      !!process.env.CI && process.env.SKIP_DND_TESTS === 'true',
-      'CDP DnD tests can be flaky in CI',
-    )
-
     await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
@@ -175,24 +163,26 @@ test.describe('Board DnD Reordering', () => {
       { steps: 15, stepDelay: 50, dropDelay: 200 },
     )
 
-    // Wait for server action to complete by polling DB
+    // Wait for server action to complete before checking persisted order.
     await page.waitForLoadState('networkidle')
 
-    // Query DB to verify positions were updated
-    const boardsAfter = await querySupabase<{
-      id: string
-      position: number
-    }>('board')
+    await expect(async () => {
+      const boardsAfter = await querySupabase<{
+        id: string
+        position: number
+      }>('board')
 
-    const wpAfter = boardsAfter.find((b) => b.id === BOARD_IDS.workProjects)
-    const tbAfter = boardsAfter.find((b) => b.id === BOARD_IDS.testBoard)
+      const wpAfter = boardsAfter.find((b) => b.id === BOARD_IDS.workProjects)
+      const tbAfter = boardsAfter.find((b) => b.id === BOARD_IDS.testBoard)
+      expect(wpAfter).toBeDefined()
+      expect(tbAfter).toBeDefined()
 
-    // After swap: relative positions should have swapped
-    // If WP was at lower position than TB, it should now be at higher (and vice versa)
-    if (wpBefore!.position < tbBefore!.position) {
-      expect(wpAfter!.position).toBeGreaterThan(tbAfter!.position)
-    } else {
-      expect(wpAfter!.position).toBeLessThan(tbAfter!.position)
-    }
+      // After swap: relative positions should have swapped.
+      if (wpBefore!.position < tbBefore!.position) {
+        expect(wpAfter!.position).toBeGreaterThan(tbAfter!.position)
+      } else {
+        expect(wpAfter!.position).toBeLessThan(tbAfter!.position)
+      }
+    }).toPass({ timeout: 10000 })
   })
 })

--- a/e2e/logged-in/kanban-dnd/card-dnd.spec.ts
+++ b/e2e/logged-in/kanban-dnd/card-dnd.spec.ts
@@ -376,21 +376,14 @@ test.describe('10.2 Card Drag & Drop', () => {
         },
       )
 
-      // Wait for server action to complete
-      await page.waitForTimeout(1500)
-
-      // Verify card status_id is updated in database
-      const cardAfter = await querySingle<{ status_id: string }>('repocard', {
-        id: cardId,
-      })
-      expect(cardAfter).not.toBeNull()
-
-      // CDP drag is inherently flaky — skip DB assertions if drag didn't register
-      test.skip(
-        cardAfter?.status_id === initialStatusId,
-        'CDP drag did not register — skipping DB verification (DnD flakiness)',
-      )
-      expect(cardAfter?.status_id).toBe(STATUS_IDS.productionRelease)
+      await expect(async () => {
+        const cardAfter = await querySingle<{ status_id: string }>('repocard', {
+          id: cardId,
+        })
+        expect(cardAfter).not.toBeNull()
+        expect(cardAfter?.status_id).not.toBe(initialStatusId)
+        expect(cardAfter?.status_id).toBe(STATUS_IDS.productionRelease)
+      }).toPass({ timeout: 10000 })
     })
   })
 })

--- a/e2e/logged-in/kanban-dnd/column-dnd.spec.ts
+++ b/e2e/logged-in/kanban-dnd/column-dnd.spec.ts
@@ -1736,24 +1736,16 @@ test.describe('10.3 Column Drag & Drop', () => {
         dropDelay: 350,
       })
 
-      // Wait for server action to complete
-      await page.waitForTimeout(1500)
-
-      // Verify column position is updated in database
-      const statusAfter = await querySingle<{
-        grid_row: number
-        grid_col: number
-      }>('statuslist', { id: statusId })
-      expect(statusAfter).not.toBeNull()
-
-      // CDP drag is inherently flaky — skip DB assertions if drag didn't register
-      // (the visual DnD tests already cover the drag interaction itself)
-      test.skip(
-        statusAfter?.grid_row === initialRow,
-        'CDP drag did not register — skipping DB verification (DnD flakiness)',
-      )
-      expect(statusAfter?.grid_row).not.toBe(initialRow)
-      expect(statusAfter?.grid_col).toBe(0) // First (only) column in new row — 0-indexed
+      await expect(async () => {
+        const statusAfter = await querySingle<{
+          grid_row: number
+          grid_col: number
+        }>('statuslist', { id: statusId })
+        expect(statusAfter).not.toBeNull()
+        expect(statusAfter?.grid_row).not.toBe(initialRow)
+        // First column in the newly created row uses zero-indexed DB coordinates.
+        expect(statusAfter?.grid_col).toBe(0)
+      }).toPass({ timeout: 10000 })
     })
   })
 })

--- a/e2e/logged-in/sidebar-collapse.spec.ts
+++ b/e2e/logged-in/sidebar-collapse.spec.ts
@@ -19,9 +19,12 @@ test.describe('Sidebar Collapse', () => {
   test.use({ storageState: 'e2e/.auth/user.json' })
 
   test.beforeEach(async ({ page }) => {
-    // Clear localStorage to start with default (expanded) state
+    // Clear persisted state only once per test context, not on full page reloads.
     await page.addInitScript(() => {
+      if (sessionStorage.getItem('gitbox-e2e-storage-cleared')) return
+
       localStorage.removeItem('gitbox-state')
+      sessionStorage.setItem('gitbox-e2e-storage-cleared', 'true')
     })
   })
 
@@ -156,15 +159,7 @@ test.describe('Sidebar Collapse', () => {
     await expect(page.locator('aside')).toHaveClass(/w-16/)
   })
 
-  /**
-   * Note: Persistence across full page reload is handled by Redux Storage Middleware
-   * with debounced writes. This test is skipped in E2E because the timing between
-   * state change → localStorage write → page reload is sensitive to debounce delay.
-   * The persistence is verified manually and in unit tests.
-   */
-  test.skip('should persist collapsed state after page reload', async ({
-    page,
-  }) => {
+  test('should persist collapsed state after page reload', async ({ page }) => {
     await page.goto('/boards')
     await page.waitForLoadState('networkidle')
 
@@ -177,12 +172,15 @@ test.describe('Sidebar Collapse', () => {
 
     await expect(sidebar).toHaveClass(/w-16/)
 
-    // Wait for localStorage write via polling
+    // Poll the debounced Redux storage write before forcing a full reload.
     await expect(async () => {
-      const stored = await page.evaluate(() =>
-        localStorage.getItem('gitbox-state'),
-      )
-      expect(stored).not.toBeNull()
+      const isPersisted = await page.evaluate(() => {
+        const stored = localStorage.getItem('gitbox-state')
+        if (!stored) return false
+
+        return JSON.parse(stored)?.state?.settings?.sidebarCollapsed === true
+      })
+      expect(isPersisted).toBe(true)
     }).toPass({ timeout: 10000 })
 
     await page.reload()

--- a/src/app/board/[id]/BoardPageClient.tsx
+++ b/src/app/board/[id]/BoardPageClient.tsx
@@ -281,9 +281,6 @@ export const BoardPageClient = memo(function BoardPageClient({
                   )
                   dispatch(addRepoCards(newCards))
                 }}
-                onQuickNoteFocus={() => {
-                  // TODO: Focus on quick note field (not yet implemented)
-                }}
               />
               <Button
                 variant="outline"

--- a/src/components/Board/AddRepositoryCombobox.stories.tsx
+++ b/src/components/Board/AddRepositoryCombobox.stories.tsx
@@ -31,7 +31,6 @@ export const Default: Story = {
     boardId: toBoardId('board-1'),
     statusId: toStatusListId('status-1'),
     onRepositoriesAdded: () => console.log('Repositories added'),
-    onQuickNoteFocus: () => console.log('Quick note focused'),
   },
 }
 
@@ -41,9 +40,6 @@ export const WithCallbacks: Story = {
     statusId: toStatusListId('status-1'),
     onRepositoriesAdded: () => {
       console.log('Repositories added successfully')
-    },
-    onQuickNoteFocus: () => {
-      console.log('Focus moved to quick note')
     },
   },
 }
@@ -56,7 +52,6 @@ export const OpenPopover: Story = {
     boardId: toBoardId('board-1'),
     statusId: toStatusListId('status-1'),
     onRepositoriesAdded: fn(),
-    onQuickNoteFocus: fn(),
   },
   play: async () => {
     // Wait for component to render
@@ -94,7 +89,6 @@ export const SearchInput: Story = {
     boardId: toBoardId('board-1'),
     statusId: toStatusListId('status-1'),
     onRepositoriesAdded: fn(),
-    onQuickNoteFocus: fn(),
   },
   play: async () => {
     // Wait for component to render
@@ -141,7 +135,6 @@ export const CancelButton: Story = {
     boardId: toBoardId('board-1'),
     statusId: toStatusListId('status-1'),
     onRepositoriesAdded: fn(),
-    onQuickNoteFocus: fn(),
   },
   play: async () => {
     // Wait for component to render

--- a/src/components/Board/AddRepositoryCombobox.tsx
+++ b/src/components/Board/AddRepositoryCombobox.tsx
@@ -40,7 +40,6 @@ interface AddRepositoryComboboxProps {
    * @param cards - The created repo cards for optimistic UI update
    */
   onRepositoriesAdded: (cards: CreatedRepoCard[]) => void
-  onQuickNoteFocus: () => void
   /**
    * Controlled mode: External open state
    * When provided, the component uses this value instead of internal state
@@ -68,13 +67,11 @@ interface AddRepositoryComboboxProps {
  * - Performance optimized (<1s response)
  * - WCAG AA accessibility compliance
  * - Duplicate detection
- * - Auto-focus to Quick note after adding
  */
 export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
   boardId,
   statusId,
   onRepositoriesAdded,
-  onQuickNoteFocus,
   isOpen: controlledIsOpen,
   onOpenChange,
   maintenanceRepoIdentifiers,
@@ -312,11 +309,6 @@ export const AddRepositoryCombobox = memo(function AddRepositoryCombobox({
 
       // Pass created cards for optimistic UI update (no page reload needed)
       onRepositoriesAdded(result.data.cards || [])
-
-      // Auto-focus to Quick note field (T046)
-      setTimeout(() => {
-        onQuickNoteFocus()
-      }, 100)
     } catch (err) {
       setAddingError(
         err instanceof Error ? err.message : 'Error adding repositories',

--- a/src/components/editor/transforms.ts
+++ b/src/components/editor/transforms.ts
@@ -3,14 +3,6 @@
 import { insertCallout } from '@platejs/callout'
 import { insertCodeBlock, toggleCodeBlock } from '@platejs/code-block'
 import { insertDate } from '@platejs/date'
-// Excalidraw not installed - stub function
-const insertExcalidraw = (
-  _editor: PlateEditor,
-  _value: object,
-  _options: object,
-) => {
-  console.warn('Excalidraw is not available')
-}
 import { insertColumnGroup, toggleColumnGroup } from '@platejs/layout'
 import { triggerFloatingLink } from '@platejs/link/react'
 import { insertEquation, insertInlineEquation } from '@platejs/math'
@@ -57,7 +49,6 @@ const insertBlockMap: Record<
   [KEYS.callout]: (editor) => insertCallout(editor, { select: true }),
   [KEYS.codeBlock]: (editor) => insertCodeBlock(editor, { select: true }),
   [KEYS.equation]: (editor) => insertEquation(editor, { select: true }),
-  [KEYS.excalidraw]: (editor) => insertExcalidraw(editor, {}, { select: true }),
   [KEYS.file]: (editor) => insertFilePlaceholder(editor, { select: true }),
   [KEYS.img]: async (editor) =>
     insertMedia(editor, {

--- a/src/components/ui/insert-toolbar-button.tsx
+++ b/src/components/ui/insert-toolbar-button.tsx
@@ -15,7 +15,6 @@ import {
   ListIcon,
   ListOrderedIcon,
   MinusIcon,
-  PenToolIcon,
   PilcrowIcon,
   PlusIcon,
   QuoteIcon,
@@ -173,11 +172,6 @@ const groups: Group[] = [
         icon: <RadicalIcon />,
         label: 'Equation',
         value: KEYS.equation,
-      },
-      {
-        icon: <PenToolIcon />,
-        label: 'Excalidraw',
-        value: KEYS.excalidraw,
       },
     ].map((item) => ({
       ...item,

--- a/src/components/ui/slash-node.tsx
+++ b/src/components/ui/slash-node.tsx
@@ -11,7 +11,6 @@ import {
   LightbulbIcon,
   ListIcon,
   ListOrdered,
-  PenToolIcon,
   PilcrowIcon,
   Quote,
   RadicalIcon,
@@ -154,12 +153,6 @@ const groups: Group[] = [
         icon: <RadicalIcon />,
         label: 'Equation',
         value: KEYS.equation,
-      },
-      {
-        icon: <PenToolIcon />,
-        keywords: ['excalidraw'],
-        label: 'Excalidraw',
-        value: KEYS.excalidraw,
       },
     ].map((item) => ({
       ...item,

--- a/src/tests/unit/components/editor/transforms.test.ts
+++ b/src/tests/unit/components/editor/transforms.test.ts
@@ -146,7 +146,6 @@ describe('insertBlock logic', () => {
     'callout',
     'code_block',
     'equation',
-    'excalidraw',
     'file',
     'img',
     'media_embed',
@@ -157,7 +156,7 @@ describe('insertBlock logic', () => {
 
   it('should have all expected block types in the insert map', () => {
     // Verify the expected block types are defined
-    expect(insertBlockTypes.length).toBe(15)
+    expect(insertBlockTypes.length).toBe(14)
   })
 
   it('should include list types', () => {

--- a/supabase/migrations/20251117_disable_rls_for_testing.sql
+++ b/supabase/migrations/20251117_disable_rls_for_testing.sql
@@ -1,5 +1,5 @@
 -- Temporary: Disable RLS for E2E testing
--- TODO: Re-enable RLS and add proper authentication setup for E2E tests
+-- Historical note: RLS was re-enabled by 20260208_reenable_rls_optimized_policies.sql
 
 -- Disable RLS on all tables
 ALTER TABLE Board DISABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Summary

- Remove the unimplemented Excalidraw editor command from the insert toolbar, slash menu, and transform map.
- Remove the no-op quick note focus callback from the add repository flow.
- Replace soft-skipped DnD E2E guards with polling assertions that verify persisted database state.
- Restore full-reload sidebar collapse persistence coverage.
- Replace the stale historical RLS TODO with an accurate migration note.

## Issues

Closes #189
Closes #190
Closes #191
Closes #192
Closes #193

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm build`
- `pnpm typecheck`
- `pnpm e2e:parallel`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of drag-and-drop persistence tests with retry logic.
  * Fixed sidebar collapse state persistence after page reload.

* **Removed Features**
  * Removed Excalidraw diagram block insertion from the editor toolbar and slash commands.

* **Tests**
  * Updated E2E tests to eliminate flaky timing dependencies and use robust polling mechanisms.
  * Updated unit test assertions to reflect removed block types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/gitbox/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->