### PR TITLE
perf(auth): swap getUser() for getClaims() in proxy + 8 server actions

### DIFF
--- a/src/app/boards/favorites/page.tsx
+++ b/src/app/boards/favorites/page.tsx
@@ -11,7 +11,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 import { BoardGrid } from '@/components/Boards'
-import { requireUser } from '@/lib/auth/require-user'
+import { requireClaims } from '@/lib/auth/require-claims'
 import type { Tables } from '@/lib/supabase/types'
 
 export const metadata: Metadata = {
@@ -20,13 +20,13 @@ export const metadata: Metadata = {
 }
 
 export default async function FavoritesPage() {
-  const { supabase, user } = await requireUser()
+  const { supabase, claims } = await requireClaims()
 
   // Fetch favorite boards
   const { data: boards, error } = (await supabase
     .from('board')
     .select('*')
-    .eq('user_id', user.id)
+    .eq('user_id', claims.sub)
     .eq('is_favorite', true)
     .order('updated_at', { ascending: false })) as {
     data: Tables<'board'>[] | null
@@ -35,7 +35,7 @@ export default async function FavoritesPage() {
 
   if (error) {
     Sentry.captureException(error, {
-      extra: { context: 'Fetch favorite boards', userId: user.id },
+      extra: { context: 'Fetch favorite boards', userId: claims.sub },
     })
   }
 

--- a/src/app/boards/new/page.tsx
+++ b/src/app/boards/new/page.tsx
@@ -8,7 +8,7 @@
 
 import type { Metadata } from 'next'
 
-import { requireUser } from '@/lib/auth/require-user'
+import { requireClaims } from '@/lib/auth/require-claims'
 
 import { CreateBoardForm } from './CreateBoardForm'
 
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 }
 
 export default async function NewBoardPage() {
-  await requireUser()
+  await requireClaims()
 
   return (
     <div className="bg-background min-h-screen">

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link'
 
 import { BoardGrid } from '@/components/Boards'
 import { Button } from '@/components/ui/button'
-import { requireUser } from '@/lib/auth/require-user'
+import { requireClaims } from '@/lib/auth/require-claims'
 
 import { BoardsPageHeader } from './BoardsPageHeader'
 
@@ -23,31 +23,31 @@ export const metadata: Metadata = {
 }
 
 export default async function BoardsPage() {
-  const { supabase, user } = await requireUser()
+  const { supabase, claims } = await requireClaims()
 
   // Fetch boards and user settings in parallel
   const [boardsResult, settingsResult] = await Promise.all([
     supabase
       .from('board')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .order('position', { ascending: true }),
     supabase
       .from('user_settings')
       .select('boards_page_title, boards_page_subtitle')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .maybeSingle(),
   ])
 
   if (boardsResult.error) {
     Sentry.captureException(boardsResult.error, {
-      extra: { context: 'Fetch boards list', userId: user.id },
+      extra: { context: 'Fetch boards list', userId: claims.sub },
     })
   }
 
   if (settingsResult.error) {
     Sentry.captureException(settingsResult.error, {
-      extra: { context: 'Fetch user settings', userId: user.id },
+      extra: { context: 'Fetch user settings', userId: claims.sub },
     })
   }
 

--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -10,7 +10,7 @@
 
 import type { Metadata } from 'next'
 
-import { requireUser } from '@/lib/auth/require-user'
+import { requireClaims } from '@/lib/auth/require-claims'
 import { createModuleLogger } from '@/lib/logger'
 import { toMaintenanceId } from '@/lib/types/brands'
 
@@ -24,13 +24,13 @@ export const metadata: Metadata = {
 const log = createModuleLogger('maintenance')
 
 export default async function MaintenancePage() {
-  const { supabase, user } = await requireUser()
+  const { supabase, claims } = await requireClaims()
 
   // Fetch maintenance repos from the maintenance table
   const { data: maintenanceData, error } = await supabase
     .from('maintenance')
     .select('*')
-    .eq('user_id', user.id)
+    .eq('user_id', claims.sub)
     .order('updated_at', { ascending: false })
 
   if (error) {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -8,7 +8,7 @@
 
 import type { Metadata } from 'next'
 
-import { requireUser } from '@/lib/auth/require-user'
+import { requireClaims } from '@/lib/auth/require-claims'
 
 import { SettingsClient } from './SettingsClient'
 
@@ -18,6 +18,6 @@ export const metadata: Metadata = {
 }
 
 export default async function SettingsPage() {
-  await requireUser()
+  await requireClaims()
   return <SettingsClient />
 }

--- a/src/lib/actions/auth-guard.ts
+++ b/src/lib/actions/auth-guard.ts
@@ -9,54 +9,55 @@
  * | `withAuthResultRateLimit` | `ActionResult<T>`| Yes        | All mutations               |
  * | `withAuthRateLimit<T>`   | `T` (throws)     | Yes        | DnD optimistic ops (throw)  |
  *
+ * Identity comes from `getCachedClaims()` (JWKS-verified JWT) instead of
+ * `getUser()` (Auth server round-trip). The action callback receives
+ * `claims` instead of `user`; use `claims.sub` for the user UUID.
+ *
  * @example
  * ```ts
  * // Read-only (no rate limit)
  * export const getPresets = () =>
- *   withAuthResult(async (supabase, user) => { ... })
+ *   withAuthResult(async (supabase, claims) => { ... })
  *
  * // Mutation (rate limited, returns ActionResult)
  * export const createBoard = (name: string) =>
- *   withAuthResultRateLimit('boardCrud', async (supabase, user) => { ... })
+ *   withAuthResultRateLimit('boardCrud', async (supabase, claims) => { ... })
  *
  * // DnD (rate limited, throws for try/catch rollback)
  * export const batchUpdate = (updates: ...) =>
- *   withAuthRateLimit('batchDnD', async (supabase, user) => { ... })
+ *   withAuthRateLimit('batchDnD', async (supabase, claims) => { ... })
  * ```
  */
 
 'use server'
 
 import * as Sentry from '@sentry/nextjs'
-import type { SupabaseClient, User } from '@supabase/supabase-js'
+import type { SupabaseClient } from '@supabase/supabase-js'
 
+import {
+  getCachedClaims,
+  type SupabaseClaims,
+} from '@/lib/auth/get-cached-claims'
 import { checkRateLimit } from '@/lib/rate-limit/check'
 import type { RateLimitKey } from '@/lib/rate-limit/config'
-import { createClient } from '@/lib/supabase/server'
 import type { Database } from '@/lib/supabase/types'
 
 import type { ActionResult } from './types'
 
 type AuthedAction<T> = (
   supabase: SupabaseClient<Database>,
-  user: User,
+  claims: SupabaseClaims,
 ) => Promise<T>
 
 /**
- * Resolve the current authenticated user, returning `null` when unauthenticated.
- * Centralizes the `supabase.auth.getUser()` pattern used by all guards.
+ * Resolve the current authenticated claims, returning `null` when unauthenticated.
+ * Centralizes the JWKS-verified `getClaims()` pattern used by all guards.
  */
 async function getAuthedContext(): Promise<{
   supabase: SupabaseClient<Database>
-  user: User
+  claims: SupabaseClaims
 } | null> {
-  const supabase = await createClient()
-  const {
-    data: { user },
-    error,
-  } = await supabase.auth.getUser()
-  if (error || !user) return null
-  return { supabase, user }
+  return getCachedClaims()
 }
 
 // Always return a generic message to clients — Sentry.captureException
@@ -79,7 +80,7 @@ export async function withAuthResult<T>(
   if (!ctx) return { success: false, error: 'Authentication required' }
 
   try {
-    const data = await action(ctx.supabase, ctx.user)
+    const data = await action(ctx.supabase, ctx.claims)
     return { success: true, data }
   } catch (error) {
     Sentry.captureException(error, { extra: { context: 'withAuthResult' } })
@@ -101,13 +102,13 @@ export async function withAuthResultRateLimit<T>(
   const ctx = await getAuthedContext()
   if (!ctx) return { success: false, error: 'Authentication required' }
 
-  const rlResult = checkRateLimit(rateLimitKey, ctx.user.id)
+  const rlResult = checkRateLimit(rateLimitKey, ctx.claims.sub)
   if (!rlResult.allowed) {
     return { success: false, error: rlResult.error! }
   }
 
   try {
-    const data = await action(ctx.supabase, ctx.user)
+    const data = await action(ctx.supabase, ctx.claims)
     return { success: true, data }
   } catch (error) {
     Sentry.captureException(error, {
@@ -130,8 +131,8 @@ export async function withAuthRateLimit<T>(
   const ctx = await getAuthedContext()
   if (!ctx) throw new Error('Authentication required')
 
-  const rlResult = checkRateLimit(rateLimitKey, ctx.user.id)
+  const rlResult = checkRateLimit(rateLimitKey, ctx.claims.sub)
   if (!rlResult.allowed) throw new Error(rlResult.error!)
 
-  return action(ctx.supabase, ctx.user)
+  return action(ctx.supabase, ctx.claims)
 }

--- a/src/lib/actions/board-data.ts
+++ b/src/lib/actions/board-data.ts
@@ -18,8 +18,8 @@
 
 'use server'
 
+import { getCachedClaims } from '@/lib/auth/get-cached-claims'
 import type { StatusListDomain, RepoCardDomain } from '@/lib/models/domain'
-import { createClient } from '@/lib/supabase/server'
 import type { RepoIdentifier } from '@/lib/types/domain-primitives'
 
 import { getBoardData } from './board'
@@ -57,17 +57,14 @@ export interface BoardInitialData {
 export async function getUserMaintenanceRepoIdentifiers(): Promise<
   RepoIdentifier[]
 > {
-  const supabase = await createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) return []
+  const authedContext = await getCachedClaims()
+  if (!authedContext) return []
+  const { supabase, claims } = authedContext
 
   const { data } = await supabase
     .from('maintenance')
     .select('repo_owner, repo_name')
-    .eq('user_id', user.id)
+    .eq('user_id', claims.sub)
 
   return (data || []).map(
     (item) =>

--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -15,6 +15,7 @@ import {
   withAuthResultRateLimit,
 } from '@/lib/actions/auth-guard'
 import { toRepoCardDomain, toStatusListDomain } from '@/lib/actions/mappers'
+import { getCachedClaims } from '@/lib/auth/get-cached-claims'
 import {
   getPresetById,
   DEFAULT_PRESET_ID,
@@ -503,12 +504,12 @@ export async function createBoard(
     return { success: false, error: 'Invalid preset selection' }
   }
 
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     // Auto-assign position: append to end of user's board list
     const { data: maxPositionRow } = await supabase
       .from('board')
       .select('position')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .order('position', { ascending: false })
       .limit(1)
       .single()
@@ -518,7 +519,7 @@ export async function createBoard(
     const { data, error } = await supabase
       .from('board')
       .insert({
-        user_id: user.id,
+        user_id: claims.sub,
         name,
         position: nextPosition,
       })
@@ -758,23 +759,18 @@ export type ToggleFavoriteState = {
 export async function toggleBoardFavorite(
   boardId: string,
 ): Promise<ToggleFavoriteState> {
-  const supabase = await createClient()
-
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
-
-  if (userError || !user) {
+  const authedContext = await getCachedClaims()
+  if (!authedContext) {
     return { success: false, error: 'Authentication required' }
   }
+  const { supabase, claims } = authedContext
 
   // Get current status
   const { data: board, error: fetchError } = await supabase
     .from('board')
     .select('is_favorite')
     .eq('id', boardId)
-    .eq('user_id', user.id)
+    .eq('user_id', claims.sub)
     .single()
 
   if (fetchError || !board) {
@@ -1212,7 +1208,7 @@ export async function toggleBoardPublic(
   boardId: string,
   isPublic: boolean,
 ): Promise<ActionResult<{ is_public: boolean; share_slug: string | null }>> {
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     const idResult = boardIdSchema.safeParse(boardId)
     if (!idResult.success) throw new Error('Invalid board ID')
 
@@ -1221,7 +1217,7 @@ export async function toggleBoardPublic(
       .from('board')
       .select('share_slug')
       .eq('id', idResult.data)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .single()
 
     if (fetchError || !board) throw new Error('Board not found')
@@ -1234,7 +1230,7 @@ export async function toggleBoardPublic(
       .from('board')
       .update({ is_public: isPublic, share_slug: shareSlug })
       .eq('id', idResult.data)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
 
     if (updateError) {
       Sentry.captureException(updateError, {

--- a/src/lib/actions/maintenance-project-info.ts
+++ b/src/lib/actions/maintenance-project-info.ts
@@ -256,12 +256,12 @@ export async function deleteMaintenanceComment(
 export async function deleteMaintenanceItem(
   maintenanceId: string,
 ): Promise<ActionResult<void>> {
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     const { error: deleteError } = await supabase
       .from('maintenance')
       .delete()
       .eq('id', maintenanceId)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
 
     if (deleteError) {
       throw Object.assign(new Error('Failed to delete maintenance item'), {

--- a/src/lib/actions/repo-cards.ts
+++ b/src/lib/actions/repo-cards.ts
@@ -105,123 +105,126 @@ export async function addRepositoriesToBoard(
     duplicateWarnings?: string[]
   }>
 > {
-  return withAuthResultRateLimit('addReposToBoard', async (supabase, user) => {
-    // Check if board exists and user owns it
-    const { data: board, error: boardError } = await supabase
-      .from('board')
-      .select('id, user_id')
-      .eq('id', boardId)
-      .eq('user_id', user.id)
-      .single()
+  return withAuthResultRateLimit(
+    'addReposToBoard',
+    async (supabase, claims) => {
+      // Check if board exists and user owns it
+      const { data: board, error: boardError } = await supabase
+        .from('board')
+        .select('id, user_id')
+        .eq('id', boardId)
+        .eq('user_id', claims.sub)
+        .single()
 
-    if (boardError || !board) {
-      throw new Error('Board not found')
-    }
+      if (boardError || !board) {
+        throw new Error('Board not found')
+      }
 
-    // Get existing cards and check for duplicates
-    const { data: existingCards, error: existingError } = await supabase
-      .from('repocard')
-      .select('repo_owner, repo_name')
-      .eq('board_id', boardId)
+      // Get existing cards and check for duplicates
+      const { data: existingCards, error: existingError } = await supabase
+        .from('repocard')
+        .select('repo_owner, repo_name')
+        .eq('board_id', boardId)
 
-    if (existingError) {
-      throw new Error('Failed to fetch existing cards')
-    }
+      if (existingError) {
+        throw new Error('Failed to fetch existing cards')
+      }
 
-    const existingRepoKeys = new Set(
-      existingCards?.map((card) => `${card.repo_owner}/${card.repo_name}`) ||
-        [],
-    )
-
-    // Also exclude repos in maintenance mode (defense-in-depth)
-    const { data: maintenanceRepos } = await supabase
-      .from('maintenance')
-      .select('repo_owner, repo_name')
-      .eq('user_id', user.id)
-
-    for (const m of maintenanceRepos || []) {
-      existingRepoKeys.add(`${m.repo_owner}/${m.repo_name}`)
-    }
-
-    // Filter to only non-duplicate repositories
-    const newRepos = repositories.filter((repo) => {
-      const key = `${repo.owner.login}/${repo.name}`
-      return !existingRepoKeys.has(key)
-    })
-
-    if (newRepos.length === 0) {
-      throw new Error('All repositories have already been added')
-    }
-
-    // Get current maximum order value
-    const { data: maxOrderData } = await supabase
-      .from('repocard')
-      .select('order')
-      .eq('status_id', statusId)
-      .order('order', { ascending: false })
-      .limit(1)
-      .single()
-
-    let nextOrder = (maxOrderData?.order ?? -1) + 1
-
-    // Add new cards
-    const cardsToInsert = newRepos.map((repo) => ({
-      board_id: boardId,
-      status_id: statusId,
-      repo_owner: repo.owner.login,
-      repo_name: repo.name,
-      order: nextOrder++,
-      meta: {
-        stars: repo.stargazers_count,
-        language: repo.language,
-        topics: repo.topics || [],
-        visibility: repo.visibility,
-        description: repo.description,
-        updatedAt: repo.updated_at,
-      },
-    }))
-
-    const { data: insertedCards, error: insertError } = await supabase
-      .from('repocard')
-      .insert(cardsToInsert)
-      .select(
-        'id, board_id, status_id, repo_owner, repo_name, order, meta, created_at, updated_at',
+      const existingRepoKeys = new Set(
+        existingCards?.map((card) => `${card.repo_owner}/${card.repo_name}`) ||
+          [],
       )
 
-    if (insertError) {
-      log.error({ error: insertError }, 'RepoCard insert error')
-      Sentry.captureException(insertError, {
-        extra: { context: 'RepoCard insert', boardId },
+      // Also exclude repos in maintenance mode (defense-in-depth)
+      const { data: maintenanceRepos } = await supabase
+        .from('maintenance')
+        .select('repo_owner, repo_name')
+        .eq('user_id', claims.sub)
+
+      for (const m of maintenanceRepos || []) {
+        existingRepoKeys.add(`${m.repo_owner}/${m.repo_name}`)
+      }
+
+      // Filter to only non-duplicate repositories
+      const newRepos = repositories.filter((repo) => {
+        const key = `${repo.owner.login}/${repo.name}`
+        return !existingRepoKeys.has(key)
       })
-      throw new Error('Failed to add cards: ' + insertError.message)
-    }
 
-    // Transform database response to CreatedRepoCard format
-    const createdCards: CreatedRepoCard[] = (insertedCards || []).map(
-      (card) => ({
-        id: toRepoCardId(card.id),
-        boardId: toBoardId(card.board_id),
-        statusId: toStatusListId(card.status_id),
-        repoOwner: card.repo_owner,
-        repoName: card.repo_name,
-        order: card.order,
-        meta: card.meta as CreatedRepoCard['meta'],
-        createdAt: card.created_at ?? new Date().toISOString(),
-        updatedAt: card.updated_at ?? new Date().toISOString(),
-      }),
-    )
+      if (newRepos.length === 0) {
+        throw new Error('All repositories have already been added')
+      }
 
-    const duplicateCount = repositories.length - newRepos.length
+      // Get current maximum order value
+      const { data: maxOrderData } = await supabase
+        .from('repocard')
+        .select('order')
+        .eq('status_id', statusId)
+        .order('order', { ascending: false })
+        .limit(1)
+        .single()
 
-    return {
-      addedCount: newRepos.length,
-      cards: createdCards,
-      duplicateWarnings:
-        duplicateCount > 0
-          ? [`${duplicateCount} repositories were duplicates`]
-          : undefined,
-    }
-  })
+      let nextOrder = (maxOrderData?.order ?? -1) + 1
+
+      // Add new cards
+      const cardsToInsert = newRepos.map((repo) => ({
+        board_id: boardId,
+        status_id: statusId,
+        repo_owner: repo.owner.login,
+        repo_name: repo.name,
+        order: nextOrder++,
+        meta: {
+          stars: repo.stargazers_count,
+          language: repo.language,
+          topics: repo.topics || [],
+          visibility: repo.visibility,
+          description: repo.description,
+          updatedAt: repo.updated_at,
+        },
+      }))
+
+      const { data: insertedCards, error: insertError } = await supabase
+        .from('repocard')
+        .insert(cardsToInsert)
+        .select(
+          'id, board_id, status_id, repo_owner, repo_name, order, meta, created_at, updated_at',
+        )
+
+      if (insertError) {
+        log.error({ error: insertError }, 'RepoCard insert error')
+        Sentry.captureException(insertError, {
+          extra: { context: 'RepoCard insert', boardId },
+        })
+        throw new Error('Failed to add cards: ' + insertError.message)
+      }
+
+      // Transform database response to CreatedRepoCard format
+      const createdCards: CreatedRepoCard[] = (insertedCards || []).map(
+        (card) => ({
+          id: toRepoCardId(card.id),
+          boardId: toBoardId(card.board_id),
+          statusId: toStatusListId(card.status_id),
+          repoOwner: card.repo_owner,
+          repoName: card.repo_name,
+          order: card.order,
+          meta: card.meta as CreatedRepoCard['meta'],
+          createdAt: card.created_at ?? new Date().toISOString(),
+          updatedAt: card.updated_at ?? new Date().toISOString(),
+        }),
+      )
+
+      const duplicateCount = repositories.length - newRepos.length
+
+      return {
+        addedCount: newRepos.length,
+        cards: createdCards,
+        duplicateWarnings:
+          duplicateCount > 0
+            ? [`${duplicateCount} repositories were duplicates`]
+            : undefined,
+      }
+    },
+  )
 }
 
 /**
@@ -279,13 +282,13 @@ export async function restoreToBoard(
   boardId: string,
   statusId: string,
 ): Promise<ActionResult<{ cardId: string }>> {
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     // Fetch maintenance item with ownership check
     const { data: maintItem, error: maintError } = await supabase
       .from('maintenance')
       .select('*')
       .eq('id', maintenanceId)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .single()
 
     if (maintError || !maintItem) {
@@ -297,7 +300,7 @@ export async function restoreToBoard(
       .from('board')
       .select('id')
       .eq('id', boardId)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .single()
 
     if (boardError || !board) {
@@ -383,12 +386,12 @@ export async function getUserBoardsWithStatusLists(): Promise<
     }>
   >
 > {
-  return withAuthResult(async (supabase, user) => {
+  return withAuthResult(async (supabase, claims) => {
     // Fetch boards
     const { data: boards, error: boardsError } = await supabase
       .from('board')
       .select('id, name')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .order('created_at', { ascending: false })
 
     if (boardsError) {
@@ -472,7 +475,7 @@ export async function moveCardToBoard(
     return { success: false, error: 'Invalid ID format' }
   }
 
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     // Fetch card with board ownership check
     const { data: card, error: cardError } = await supabase
       .from('repocard')
@@ -486,7 +489,7 @@ export async function moveCardToBoard(
 
     // Verify ownership via board's user_id
     const boardData = card.board as { user_id: string } | null
-    if (!boardData || boardData.user_id !== user.id) {
+    if (!boardData || boardData.user_id !== claims.sub) {
       throw new Error('Unauthorized')
     }
 
@@ -495,7 +498,7 @@ export async function moveCardToBoard(
       .from('board')
       .select('id')
       .eq('id', targetBoardId)
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .single()
 
     if (targetBoardError || !targetBoard) {
@@ -570,7 +573,7 @@ export async function moveCardToBoard(
 export async function moveToMaintenance(
   cardId: string,
 ): Promise<ActionResult<{ maintenanceId: string }>> {
-  return withAuthResultRateLimit('boardCrud', async (supabase, user) => {
+  return withAuthResultRateLimit('boardCrud', async (supabase, claims) => {
     // Fetch card with board ownership check
     const { data: card, error: cardError } = await supabase
       .from('repocard')
@@ -584,7 +587,7 @@ export async function moveToMaintenance(
 
     // Verify ownership via board's user_id
     const boardData = card.board as { user_id: string } | null
-    if (!boardData || boardData.user_id !== user.id) {
+    if (!boardData || boardData.user_id !== claims.sub) {
       throw new Error('Unauthorized')
     }
 
@@ -592,7 +595,7 @@ export async function moveToMaintenance(
     const { data: existing } = await supabase
       .from('maintenance')
       .select('id')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .eq('repo_owner', card.repo_owner)
       .eq('repo_name', card.repo_name)
       .maybeSingle()
@@ -606,7 +609,7 @@ export async function moveToMaintenance(
       'move_to_maintenance',
       {
         p_card_id: cardId,
-        p_user_id: user.id,
+        p_user_id: claims.sub,
         p_repo_owner: card.repo_owner,
         p_repo_name: card.repo_name,
       },

--- a/src/lib/actions/user-presets.ts
+++ b/src/lib/actions/user-presets.ts
@@ -51,16 +51,16 @@ export interface UserPreset {
  * // Returns: [{ id: '...', value: 'my-service', label: 'My Service', icon: 'Link' }, ...]
  */
 export async function getUserPresets(): Promise<ActionResult<UserPreset[]>> {
-  return withAuthResult(async (supabase, user) => {
+  return withAuthResult(async (supabase, claims) => {
     const { data, error } = await supabase
       .from('user_link_presets')
       .select('id, value, label, icon')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .order('label', { ascending: true })
 
     if (error) {
       Sentry.captureException(error, {
-        extra: { context: 'Get user presets', userId: user.id },
+        extra: { context: 'Get user presets', userId: claims.sub },
       })
       throw new Error('Failed to fetch custom presets')
     }
@@ -107,16 +107,16 @@ export async function createUserPreset(
     }
   }
 
-  return withAuthResultRateLimit('userSettings', async (supabase, user) => {
+  return withAuthResultRateLimit('userSettings', async (supabase, claims) => {
     // Check preset limit
     const { count, error: countError } = await supabase
       .from('user_link_presets')
       .select('*', { count: 'exact', head: true })
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
 
     if (countError) {
       Sentry.captureException(countError, {
-        extra: { context: 'Count user presets', userId: user.id },
+        extra: { context: 'Count user presets', userId: claims.sub },
       })
       throw new Error('Failed to check preset limit')
     }
@@ -131,7 +131,7 @@ export async function createUserPreset(
     const { data: existing } = await supabase
       .from('user_link_presets')
       .select('id')
-      .eq('user_id', user.id)
+      .eq('user_id', claims.sub)
       .eq('value', value)
       .single()
 
@@ -141,7 +141,7 @@ export async function createUserPreset(
 
     // Create preset
     const insertData: UserLinkPresetInsert = {
-      user_id: user.id,
+      user_id: claims.sub,
       value,
       label: label.trim(),
       icon: icon || 'Link',
@@ -155,7 +155,7 @@ export async function createUserPreset(
 
     if (error) {
       Sentry.captureException(error, {
-        extra: { context: 'Create user preset', userId: user.id, label },
+        extra: { context: 'Create user preset', userId: claims.sub, label },
       })
       throw new Error('Failed to create custom preset')
     }

--- a/src/lib/actions/user-settings.ts
+++ b/src/lib/actions/user-settings.ts
@@ -33,10 +33,10 @@ export async function updateBoardsPageTitle(
   // Store empty string as null in DB for cleaner querying
   const dbValue = parsed.data === '' ? null : parsed.data
 
-  return withAuthResultRateLimit('userSettings', async (supabase, user) => {
+  return withAuthResultRateLimit('userSettings', async (supabase, claims) => {
     const { error } = await supabase.from('user_settings').upsert(
       {
-        user_id: user.id,
+        user_id: claims.sub,
         boards_page_title: dbValue,
         updated_at: new Date().toISOString(),
       },
@@ -45,7 +45,7 @@ export async function updateBoardsPageTitle(
 
     if (error) {
       Sentry.captureException(error, {
-        extra: { context: 'Update boards page title', userId: user.id },
+        extra: { context: 'Update boards page title', userId: claims.sub },
       })
       throw new Error('Failed to update title')
     }
@@ -77,10 +77,10 @@ export async function updateBoardsPageSubtitle(
   // Store empty string as null in DB for cleaner querying
   const dbValue = parsed.data === '' ? null : parsed.data
 
-  return withAuthResultRateLimit('userSettings', async (supabase, user) => {
+  return withAuthResultRateLimit('userSettings', async (supabase, claims) => {
     const { error } = await supabase.from('user_settings').upsert(
       {
-        user_id: user.id,
+        user_id: claims.sub,
         boards_page_subtitle: dbValue,
         updated_at: new Date().toISOString(),
       },
@@ -89,7 +89,7 @@ export async function updateBoardsPageSubtitle(
 
     if (error) {
       Sentry.captureException(error, {
-        extra: { context: 'Update boards page subtitle', userId: user.id },
+        extra: { context: 'Update boards page subtitle', userId: claims.sub },
       })
       throw new Error('Failed to update subtitle')
     }

--- a/src/lib/auth/get-cached-claims.ts
+++ b/src/lib/auth/get-cached-claims.ts
@@ -58,9 +58,10 @@ export const getCachedClaims = cache(async () => {
 
   const claims = data.claims as SupabaseClaims
 
-  // Defensive expiry check on top of SDK validation (handles clock skew).
+  // Defensive expiry check on top of SDK validation: fail closed if exp is
+  // missing, non-numeric, or already past (handles clock skew + malformed JWT).
   const nowInSeconds = Math.floor(Date.now() / 1000)
-  if (typeof claims.exp === 'number' && nowInSeconds > claims.exp) return null
+  if (typeof claims.exp !== 'number' || nowInSeconds > claims.exp) return null
 
   return { supabase, claims }
 })

--- a/src/lib/auth/get-cached-claims.ts
+++ b/src/lib/auth/get-cached-claims.ts
@@ -1,0 +1,66 @@
+import { cache } from 'react'
+
+import { createClient } from '@/lib/supabase/server'
+
+/**
+ * Standard JWT claims returned by `supabase.auth.getClaims()`.
+ *
+ * Mirrors the relevant subset of `@supabase/auth-js` JwtPayload, narrowed to the
+ * fields GitBox actually reads on the server. `sub` (user UUID) is the new
+ * source of truth for what was previously `user.id`.
+ */
+export interface SupabaseClaims {
+  iss: string
+  sub: string
+  aud: string
+  exp: number
+  iat: number
+  role: string
+  email?: string
+  phone?: string
+  session_id?: string
+  is_anonymous?: boolean
+  app_metadata?: Record<string, unknown>
+  user_metadata?: Record<string, unknown>
+}
+
+/**
+ * Request-scoped, cached fetch of the current Supabase JWT claims.
+ *
+ * Uses React.cache so multiple callers within the same Server Component
+ * tree (proxy → page → layout → server action) share a single `getClaims()`
+ * round-trip. With asymmetric signing keys this is a local WebCrypto verify
+ * (~5ms) against the JWKS endpoint — orders of magnitude faster than the
+ * ~300ms `getUser()` round-trip.
+ *
+ * A defensive `exp` check is layered on top of the SDK's own expiry
+ * validation. The SDK rejects expired tokens by default, but a manual
+ * `Date.now() / 1000 > claims.exp` guard protects against clock skew and
+ * any edge case where the SDK validation is bypassed.
+ *
+ * @returns A `{ supabase, claims }` tuple when the JWT is present and valid,
+ *   or `null` when the request is unauthenticated or the token has expired.
+ *
+ * @example
+ * ```ts
+ * const result = await getCachedClaims()
+ * if (!result) redirect('/login')
+ * const { supabase, claims } = result
+ * const { data } = await supabase.from('board').select().eq('user_id', claims.sub)
+ * ```
+ */
+export const getCachedClaims = cache(async () => {
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.getClaims()
+
+  // No session, network failure, or expired token — treat as unauthenticated.
+  if (error || !data?.claims) return null
+
+  const claims = data.claims as SupabaseClaims
+
+  // Defensive expiry check on top of SDK validation (handles clock skew).
+  const nowInSeconds = Math.floor(Date.now() / 1000)
+  if (typeof claims.exp === 'number' && nowInSeconds > claims.exp) return null
+
+  return { supabase, claims }
+})

--- a/src/lib/auth/require-claims.ts
+++ b/src/lib/auth/require-claims.ts
@@ -1,0 +1,38 @@
+import { redirect } from 'next/navigation'
+
+import { ROUTES } from '@/lib/constants/routes'
+
+import { getCachedClaims } from './get-cached-claims'
+
+/**
+ * Server Component / Server Action auth gate backed by JWT claims.
+ *
+ * Wraps `getCachedClaims()` and short-circuits to `/login` (or a caller-
+ * provided destination) when there is no valid session. Use this in place of
+ * `requireUser()` anywhere the calling code only needs the user UUID
+ * (`claims.sub`) and not the full Supabase `User` row — which is most of
+ * GitBox's server code.
+ *
+ * Falls back to `requireUser()` in `account/page.tsx`, which still needs
+ * `created_at` from the User object.
+ *
+ * @param redirectTo - Path to redirect to when unauthenticated. Defaults to `/login`.
+ * @returns `{ supabase, claims }` for use in the calling Server Component.
+ *
+ * @example
+ * ```ts
+ * export default async function BoardsPage() {
+ *   const { supabase, claims } = await requireClaims()
+ *   const { data } = await supabase
+ *     .from('board')
+ *     .select('*')
+ *     .eq('user_id', claims.sub)
+ *   // ...
+ * }
+ * ```
+ */
+export async function requireClaims(redirectTo: string = ROUTES.LOGIN) {
+  const result = await getCachedClaims()
+  if (!result) redirect(redirectTo)
+  return result
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -142,16 +142,48 @@ export async function createClient() {
         },
         error: null,
       }),
+      /**
+       * E2E mock for `supabase.auth.getClaims()`.
+       *
+       * Returns a JWT claims object derived from MOCK_USER_FOR_E2E so any
+       * server code migrating from `getUser()` to `getClaims()` keeps working
+       * under `APP_ENV=test` without requiring JWKS verification.
+       *
+       * Matches the success-branch shape of `@supabase/auth-js`:
+       * `{ data: { claims, header, signature }, error: null }`.
+       */
+      getClaims: async () => ({
+        data: {
+          claims: {
+            iss: 'supabase-demo',
+            sub: MOCK_USER_FOR_E2E.id,
+            aud: MOCK_USER_FOR_E2E.aud,
+            exp: Math.floor(Date.now() / 1000) + 3600,
+            iat: Math.floor(Date.now() / 1000),
+            role: MOCK_USER_FOR_E2E.role,
+            email: MOCK_USER_FOR_E2E.email,
+            phone: MOCK_USER_FOR_E2E.phone,
+            session_id: '00000000-0000-0000-0000-000000000010',
+            is_anonymous: MOCK_USER_FOR_E2E.is_anonymous,
+            app_metadata: MOCK_USER_FOR_E2E.app_metadata,
+            user_metadata: MOCK_USER_FOR_E2E.user_metadata,
+          },
+          header: { alg: 'HS256', typ: 'JWT' },
+          signature: new Uint8Array(),
+        },
+        error: null,
+      }),
     }
 
     return new Proxy(supabase, {
       get(target, prop) {
         if (prop === 'auth') {
-          // Return a proxy for auth that intercepts getUser/getSession
+          // Return a proxy for auth that intercepts getUser/getSession/getClaims
           return new Proxy(target.auth, {
             get(authTarget, authProp) {
               if (authProp === 'getUser') return mockedAuth.getUser
               if (authProp === 'getSession') return mockedAuth.getSession
+              if (authProp === 'getClaims') return mockedAuth.getClaims
               return (authTarget as any)[authProp]
             },
           })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -86,11 +86,20 @@ export async function proxy(request: NextRequest) {
     },
   )
 
-  // IMPORTANT: Use getUser() not getSession() for proper session refresh
-  // This also handles PKCE token exchange correctly
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  // Use getClaims() over getUser() to validate identity locally via JWKS
+  // (~5ms WebCrypto verify) instead of round-tripping to the Auth server
+  // (~300ms). The SDK rejects expired tokens by default; a manual exp guard
+  // below catches clock skew and any edge case where SDK validation is
+  // bypassed. PKCE refresh still fires through the cookie setAll plumbing
+  // when the access token is near expiry.
+  const { data: claimsData, error: claimsError } =
+    await supabase.auth.getClaims()
+  const claims = claimsData?.claims
+  const nowInSeconds = Math.floor(Date.now() / 1000)
+  const hasValidClaims =
+    !claimsError &&
+    !!claims &&
+    (typeof claims.exp !== 'number' || nowInSeconds <= claims.exp)
 
   // Allow public paths without authentication
   if (publicPaths.includes(pathname)) {
@@ -98,7 +107,7 @@ export async function proxy(request: NextRequest) {
   }
 
   // Redirect to login if not authenticated
-  if (!user) {
+  if (!hasValidClaims) {
     logSecurityEvent('unauthorized_access', { path: pathname })
     const loginUrl = new URL('/login', request.url)
     // Copy cookies to redirect response

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -99,7 +99,8 @@ export async function proxy(request: NextRequest) {
   const hasValidClaims =
     !claimsError &&
     !!claims &&
-    (typeof claims.exp !== 'number' || nowInSeconds <= claims.exp)
+    typeof claims.exp === 'number' &&
+    nowInSeconds <= claims.exp
 
   // Allow public paths without authentication
   if (publicPaths.includes(pathname)) {

--- a/src/tests/unit/lib/auth/get-cached-claims.test.ts
+++ b/src/tests/unit/lib/auth/get-cached-claims.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit Tests: getCachedClaims()
+ *
+ * Verifies the request-scoped JWT-claims helper that backs every server-side
+ * auth gate (proxy.ts, requireClaims, auth-guard.ts). Covers:
+ *
+ *  A. Happy path — valid claims pass through unchanged
+ *  B. SDK error — returns null (treat as unauthenticated)
+ *  C. Missing claims — returns null
+ *  D. Defensive expiry check — exp in the past returns null
+ *  E. Defensive expiry check — exp omitted/non-number passes through
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { createClient } from '@/lib/supabase/server'
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+const MOCK_USER_UUID = '00000000-0000-0000-0000-000000000001'
+
+// Builds a minimal Supabase client mock whose `auth.getClaims()` returns the
+// caller-supplied response, so each test can exercise a specific branch.
+function buildSupabaseMock(getClaimsResult: {
+  data: { claims: Record<string, unknown> | null } | null
+  error: unknown
+}) {
+  return {
+    auth: {
+      getClaims: vi.fn().mockResolvedValue(getClaimsResult),
+    },
+  }
+}
+
+// React.cache() memoizes per-module-load, so reset the module between tests
+// to guarantee each `it` block starts from a fresh cache.
+async function importFreshHelper() {
+  vi.resetModules()
+  return import('@/lib/auth/get-cached-claims')
+}
+
+describe('getCachedClaims()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns { supabase, claims } when the SDK returns valid claims', async () => {
+    // Arrange
+    const futureExpInSeconds = Math.floor(Date.now() / 1000) + 3600
+    const validClaims = {
+      iss: 'supabase-demo',
+      sub: MOCK_USER_UUID,
+      aud: 'authenticated',
+      exp: futureExpInSeconds,
+      iat: Math.floor(Date.now() / 1000),
+      role: 'authenticated',
+      email: 'test@example.com',
+    }
+    const supabaseMock = buildSupabaseMock({
+      data: { claims: validClaims },
+      error: null,
+    })
+    vi.mocked(createClient).mockResolvedValue(supabaseMock as never)
+
+    // Act
+    const { getCachedClaims } = await importFreshHelper()
+    const result = await getCachedClaims()
+
+    // Assert
+    expect(result).not.toBeNull()
+    expect(result?.claims.sub).toBe(MOCK_USER_UUID)
+    expect(result?.claims.exp).toBe(futureExpInSeconds)
+    expect(result?.supabase).toBe(supabaseMock)
+  })
+
+  it('returns null when the SDK reports an error', async () => {
+    // Arrange
+    const supabaseMock = buildSupabaseMock({
+      data: null,
+      error: new Error('JWKS fetch failed'),
+    })
+    vi.mocked(createClient).mockResolvedValue(supabaseMock as never)
+
+    // Act
+    const { getCachedClaims } = await importFreshHelper()
+    const result = await getCachedClaims()
+
+    // Assert
+    expect(result).toBeNull()
+  })
+
+  it('returns null when claims payload is missing', async () => {
+    // Arrange
+    const supabaseMock = buildSupabaseMock({
+      data: { claims: null },
+      error: null,
+    })
+    vi.mocked(createClient).mockResolvedValue(supabaseMock as never)
+
+    // Act
+    const { getCachedClaims } = await importFreshHelper()
+    const result = await getCachedClaims()
+
+    // Assert
+    expect(result).toBeNull()
+  })
+
+  it('returns null when the defensive exp check trips (token already expired)', async () => {
+    // Arrange — exp 60s in the past
+    const pastExpInSeconds = Math.floor(Date.now() / 1000) - 60
+    const expiredClaims = {
+      iss: 'supabase-demo',
+      sub: MOCK_USER_UUID,
+      aud: 'authenticated',
+      exp: pastExpInSeconds,
+      iat: pastExpInSeconds - 3600,
+      role: 'authenticated',
+    }
+    const supabaseMock = buildSupabaseMock({
+      data: { claims: expiredClaims },
+      error: null,
+    })
+    vi.mocked(createClient).mockResolvedValue(supabaseMock as never)
+
+    // Act
+    const { getCachedClaims } = await importFreshHelper()
+    const result = await getCachedClaims()
+
+    // Assert
+    expect(result).toBeNull()
+  })
+
+  it('passes through when exp is not a number (defensive check is opt-in)', async () => {
+    // Arrange — exp deliberately omitted (treat as "no defensive expiry")
+    const claimsWithoutExp = {
+      iss: 'supabase-demo',
+      sub: MOCK_USER_UUID,
+      aud: 'authenticated',
+      iat: Math.floor(Date.now() / 1000),
+      role: 'authenticated',
+    }
+    const supabaseMock = buildSupabaseMock({
+      data: { claims: claimsWithoutExp },
+      error: null,
+    })
+    vi.mocked(createClient).mockResolvedValue(supabaseMock as never)
+
+    // Act
+    const { getCachedClaims } = await importFreshHelper()
+    const result = await getCachedClaims()
+
+    // Assert — claims pass through; SDK would have already rejected a true bad token
+    expect(result).not.toBeNull()
+    expect(result?.claims.sub).toBe(MOCK_USER_UUID)
+  })
+})

--- a/src/tests/unit/lib/auth/get-cached-claims.test.ts
+++ b/src/tests/unit/lib/auth/get-cached-claims.test.ts
@@ -8,7 +8,7 @@
  *  B. SDK error — returns null (treat as unauthenticated)
  *  C. Missing claims — returns null
  *  D. Defensive expiry check — exp in the past returns null
- *  E. Defensive expiry check — exp omitted/non-number passes through
+ *  E. Defensive expiry check — exp omitted/non-number returns null (fail closed)
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
@@ -132,8 +132,9 @@ describe('getCachedClaims()', () => {
     expect(result).toBeNull()
   })
 
-  it('passes through when exp is not a number (defensive check is opt-in)', async () => {
-    // Arrange — exp deliberately omitted (treat as "no defensive expiry")
+  it('returns null when exp is missing or non-numeric (fail closed)', async () => {
+    // Arrange — exp deliberately omitted; a JWT without an expiry must be
+    // rejected by the auth gate even if the Supabase SDK accepted it.
     const claimsWithoutExp = {
       iss: 'supabase-demo',
       sub: MOCK_USER_UUID,
@@ -151,8 +152,7 @@ describe('getCachedClaims()', () => {
     const { getCachedClaims } = await importFreshHelper()
     const result = await getCachedClaims()
 
-    // Assert — claims pass through; SDK would have already rejected a true bad token
-    expect(result).not.toBeNull()
-    expect(result?.claims.sub).toBe(MOCK_USER_UUID)
+    // Assert — fail closed: missing exp = unauthenticated
+    expect(result).toBeNull()
   })
 })

--- a/src/tests/unit/lib/auth/require-claims.test.ts
+++ b/src/tests/unit/lib/auth/require-claims.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Unit Tests: requireClaims()
+ *
+ * Verifies the Server Component / Server Action auth gate that wraps
+ * `getCachedClaims()` and short-circuits to `/login`. Covers:
+ *
+ *  A. Happy path — returns the same { supabase, claims } from the helper
+ *  B. Unauthenticated — redirects to /login (default ROUTES.LOGIN)
+ *  C. Unauthenticated with override — redirects to caller-supplied path
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { getCachedClaims } from '@/lib/auth/get-cached-claims'
+import { ROUTES } from '@/lib/constants/routes'
+
+vi.mock('@/lib/auth/get-cached-claims', () => ({
+  getCachedClaims: vi.fn(),
+}))
+
+// next/navigation's `redirect()` throws a NEXT_REDIRECT error in real Next.
+// Mirror that contract so test code can `expect(() => ...).toThrow(...)` and
+// also assert which path the redirect targeted.
+const mockRedirect = vi.fn((path: string) => {
+  throw new Error(`NEXT_REDIRECT:${path}`)
+})
+vi.mock('next/navigation', () => ({
+  redirect: (path: string) => mockRedirect(path),
+}))
+
+describe('requireClaims()', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns { supabase, claims } when getCachedClaims resolves with a session', async () => {
+    // Arrange
+    const fakeContext = {
+      supabase: { tag: 'supabase-client' } as never,
+      claims: {
+        iss: 'supabase-demo',
+        sub: '00000000-0000-0000-0000-000000000001',
+        aud: 'authenticated',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+        role: 'authenticated',
+      },
+    }
+    vi.mocked(getCachedClaims).mockResolvedValue(fakeContext as never)
+
+    // Act
+    const { requireClaims } = await import('@/lib/auth/require-claims')
+    const result = await requireClaims()
+
+    // Assert
+    expect(result).toBe(fakeContext)
+    expect(mockRedirect).not.toHaveBeenCalled()
+  })
+
+  it('redirects to ROUTES.LOGIN when getCachedClaims returns null', async () => {
+    // Arrange
+    vi.mocked(getCachedClaims).mockResolvedValue(null)
+
+    // Act + Assert — redirect throws NEXT_REDIRECT
+    const { requireClaims } = await import('@/lib/auth/require-claims')
+    await expect(requireClaims()).rejects.toThrow(
+      `NEXT_REDIRECT:${ROUTES.LOGIN}`,
+    )
+    expect(mockRedirect).toHaveBeenCalledWith(ROUTES.LOGIN)
+  })
+
+  it('redirects to the caller-supplied path when unauthenticated', async () => {
+    // Arrange
+    vi.mocked(getCachedClaims).mockResolvedValue(null)
+    const customRedirectTarget = '/boards/favorites'
+
+    // Act + Assert
+    const { requireClaims } = await import('@/lib/auth/require-claims')
+    await expect(requireClaims(customRedirectTarget)).rejects.toThrow(
+      `NEXT_REDIRECT:${customRedirectTarget}`,
+    )
+    expect(mockRedirect).toHaveBeenCalledWith(customRedirectTarget)
+  })
+})


### PR DESCRIPTION
## Summary

Migrate the 8 server-side auth gates from `supabase.auth.getUser()` (network round-trip to the Supabase Auth API) to `supabase.auth.getClaims()` (in-process ES256 verify via WebCrypto + JWKS). Same auth posture, no protocol/format changes to the JWT, PKCE refresh still flows through the existing `setAll` plumbing.

Touched sites:
- `src/proxy.ts` — Edge proxy on every protected route
- `src/lib/actions/auth-guard.ts` — `withAuthResult` / `withAuthResultRateLimit` / `withAuthRateLimit` wrappers
- `src/lib/auth/get-cached-claims.ts` (new) — `React.cache`-wrapped claims fetch
- `src/lib/auth/require-claims.ts` (new) — Server Component gate, replaces `requireUser()` where only `claims.sub` is needed
- 6 Server Components / pages (`boards`, `boards/favorites`, `boards/new`, `maintenance`, `settings`, and the action callers in `board.ts`/`repo-cards.ts`/`user-presets.ts`/`user-settings.ts`/`board-data.ts`/`maintenance-project-info.ts`)
- 2 new test files covering the helpers

`account/page.tsx` still uses `requireUser()` because it reads `created_at` off the full `User` row.

## Why

`getUser()` calls Supabase's `/auth/v1/user` endpoint on every gated request. With asymmetric signing keys enabled, `getClaims()` verifies the JWT locally against a cached JWKS — there's no architectural reason to do a network round-trip just to confirm the JWT we already hold is signed correctly.

The defensive `exp` check layered on top of SDK validation is intentional: the SDK already rejects expired tokens, but the explicit `Date.now() / 1000 > claims.exp` guard covers clock skew and any edge case where SDK validation could be bypassed.

## Performance: exploratory only

10-run Playwright Navigation Timing on `/board/[id]` (authenticated, payload + DOM parity verified — same 1 column + 6 cards on both deployments):

| metric | prod (`getUser`) | preview (`getClaims`) |
| --- | --- | --- |
| TTFB median | 9.5 ms | 9.0 ms |
| TOTAL median | 785.5 ms | 724.0 ms |
| TOTAL stdev | 415.3 ms | 207.0 ms |

**Do not read these as a perf result.** At n=10 the standard error of the median difference is ~147 ms, so the 95% CI on the TOTAL delta is roughly `[-350, +227]` ms — it straddles zero, and the sample is too small to conclude any specific improvement.

Two things this measurement does establish:
- Browser TTFB (`responseStart - requestStart`) is invariant ~9 ms on both sides. Vercel Edge streams response headers before middleware completes, so middleware latency does not surface in browser TTFB regardless of which auth call we use. Anyone expecting a visible TTFB drop from this PR should expect zero.
- The signal points the same direction as the architectural prediction (lower median, lower variance), but the sample can't carry weight on its own.

Authoritative validation is post-deploy: Vercel Analytics p50/p75 over a few thousand real requests, and Sentry for any auth-related regressions.

## Risks

- **PKCE refresh path** — `setAll` plumbing is identical to before, but the refresh fires on a different SDK code path than `getUser`. Worth manually re-validating in staging: log in, idle past access-token expiry, refresh, confirm session still good.
- **No JWT shape change** — claim names (`sub`, `exp`, etc.) are stable. `claims.sub` replaces `user.id` 1:1.
- **`requireUser()` still in use** in `account/page.tsx` only — intentional, that page reads `created_at`.

## Test plan

- [x] `pnpm test` — 1354 tests pass (includes 2 new files: `get-cached-claims.test.ts`, `require-claims.test.ts`)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [ ] `pnpm e2e:parallel` (running)
- [ ] Manual: log in via GitHub OAuth on staging preview, idle past access-token expiry, confirm refresh works without re-login
- [ ] Post-merge: watch Vercel Analytics + Sentry for 24h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Security**
  * Switched to verified JWT claims for authentication checks, improving security and session validation across boards, settings, maintenance, and related actions
  * Updated server-side auth flow to rely on cached claims for more consistent identity handling and error reporting
* **Tests**
  * Added unit tests covering cached-claims retrieval and the auth gate behavior to ensure robust auth validation and redirects

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/gitbox/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->