### PR TITLE
perf(board): swap getUser() for requireClaims() in /board layout

### DIFF
--- a/src/app/board/layout.tsx
+++ b/src/app/board/layout.tsx
@@ -3,12 +3,14 @@
  *
  * Layout for /board/* routes
  * - Sidebar navigation
- * - Fetches user information and passes it to Sidebar
+ * - Reads JWT claims (~5ms WebCrypto verify via `requireClaims`) for header
+ *   user info, so `loading.tsx` Skeleton can stream effectively immediately
+ *   after the first byte instead of waiting on the ~50ms `auth.getUser()`
+ *   GoTrue round-trip.
  */
 
-import { redirect } from 'next/navigation'
-
-import { createClient } from '@/lib/supabase/server'
+import { requireClaims } from '@/lib/auth/require-claims'
+import { getClaimsDisplayInfo } from '@/lib/utils/get-claims-display-info'
 
 import { BoardLayoutClient } from './BoardLayoutClient'
 
@@ -17,20 +19,8 @@ export default async function BoardLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-
-  // Authentication check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  // Get user metadata
-  const userName = user.user_metadata?.full_name || user.email || 'User'
-  const userAvatar = user.user_metadata?.avatar_url
+  const { claims } = await requireClaims()
+  const { userName, userAvatar } = getClaimsDisplayInfo(claims)
 
   return (
     <BoardLayoutClient userName={userName} userAvatar={userAvatar}>

--- a/src/lib/utils/get-claims-display-info.ts
+++ b/src/lib/utils/get-claims-display-info.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClaims } from '@/lib/auth/get-cached-claims'
+
+interface ClaimsDisplayInfo {
+  userName: string
+  userAvatar: string | undefined
+}
+
+/**
+ * Extracts display-safe header info (name, avatar URL) from Supabase JWT claims.
+ *
+ * Used by the board layout so the header chrome can render without paying for
+ * the ~50ms `auth.getUser()` GoTrue round-trip — `requireClaims()` verifies the
+ * JWT locally in ~5ms and this helper pulls the metadata fields needed for the
+ * sidebar. `user_metadata` is typed as `Record<string, unknown>` on the claim,
+ * so each field is narrowed at runtime before use.
+ *
+ * @param claims - Decoded Supabase JWT claims returned by `getCachedClaims`.
+ * @returns
+ * - `userName`: `user_metadata.full_name` (when string), else `claims.email`, else literal `'User'`
+ * - `userAvatar`: `user_metadata.avatar_url` (when string), else `undefined`
+ *
+ * @example
+ * getClaimsDisplayInfo({
+ *   sub: '00000000-0000-0000-0000-000000000001',
+ *   email: 'alice@example.com',
+ *   user_metadata: { full_name: 'Alice', avatar_url: 'https://cdn/x.png' },
+ *   // ...rest of SupabaseClaims
+ * } as SupabaseClaims)
+ * // => { userName: 'Alice', userAvatar: 'https://cdn/x.png' }
+ *
+ * @example
+ * // Missing user_metadata.full_name → falls back to email
+ * getClaimsDisplayInfo({ email: 'bob@example.com', user_metadata: {} } as SupabaseClaims)
+ * // => { userName: 'bob@example.com', userAvatar: undefined }
+ */
+export function getClaimsDisplayInfo(
+  claims: SupabaseClaims,
+): ClaimsDisplayInfo {
+  const fullNameClaim = claims.user_metadata?.full_name
+  const avatarClaim = claims.user_metadata?.avatar_url
+
+  const fullName = typeof fullNameClaim === 'string' ? fullNameClaim : null
+  const userAvatar = typeof avatarClaim === 'string' ? avatarClaim : undefined
+
+  return {
+    userName: fullName || claims.email || 'User',
+    userAvatar,
+  }
+}

--- a/src/tests/unit/lib/utils/get-claims-display-info.test.ts
+++ b/src/tests/unit/lib/utils/get-claims-display-info.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit Tests: get-claims-display-info
+ *
+ * Verifies the board layout's header info extraction from Supabase JWT claims:
+ *  - Picks `user_metadata.full_name` when present
+ *  - Falls back to `email`, then to literal `'User'`
+ *  - Returns `avatar_url` only when it is a string, else `undefined`
+ *
+ * Each test hard-codes the expected value (DAMP), follows AAA layout, and is
+ * named after the observable behavior the layout depends on.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import type { SupabaseClaims } from '@/lib/auth/get-cached-claims'
+import { getClaimsDisplayInfo } from '@/lib/utils/get-claims-display-info'
+
+/**
+ * Minimal valid claims fixture. Tests override only the fields under test so
+ * any future field added to `SupabaseClaims` won't force a rewrite here.
+ */
+const baseClaims = {
+  iss: 'supabase-demo',
+  sub: '00000000-0000-0000-0000-000000000001',
+  aud: 'authenticated',
+  exp: 9999999999,
+  iat: 1700000000,
+  role: 'authenticated',
+} satisfies SupabaseClaims
+
+describe('getClaimsDisplayInfo', () => {
+  it('uses user_metadata.full_name as the header name when available', () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'alice@example.com',
+      user_metadata: {
+        full_name: 'Alice Liddell',
+        avatar_url: 'https://cdn.example.com/alice.png',
+      },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'Alice Liddell',
+      userAvatar: 'https://cdn.example.com/alice.png',
+    })
+  })
+
+  it('falls back to email when full_name is missing from user_metadata', () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'bob@example.com',
+      user_metadata: { avatar_url: 'https://cdn.example.com/bob.png' },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'bob@example.com',
+      userAvatar: 'https://cdn.example.com/bob.png',
+    })
+  })
+
+  it("falls back to literal 'User' when both full_name and email are missing", () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      user_metadata: {},
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'User',
+      userAvatar: undefined,
+    })
+  })
+
+  it('returns avatar undefined when user_metadata is missing entirely', () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'carol@example.com',
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'carol@example.com',
+      userAvatar: undefined,
+    })
+  })
+
+  it('rejects non-string full_name and falls back to email', () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'dan@example.com',
+      // GitHub OAuth can omit/replace metadata fields. Defend against
+      // unexpected shapes coming back from the JWT.
+      user_metadata: { full_name: 12345, avatar_url: 'https://cdn/d.png' },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'dan@example.com',
+      userAvatar: 'https://cdn/d.png',
+    })
+  })
+
+  it('rejects non-string avatar_url and returns undefined', () => {
+    // Arrange
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'eve@example.com',
+      user_metadata: { full_name: 'Eve', avatar_url: { url: 'no' } },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'Eve',
+      userAvatar: undefined,
+    })
+  })
+
+  it('returns email when full_name is an empty string', () => {
+    // Arrange
+    // An empty `full_name` should not render as a blank header; the layout
+    // depends on the `||` cascade falling through to `email`.
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      email: 'fran@example.com',
+      user_metadata: { full_name: '' },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'fran@example.com',
+      userAvatar: undefined,
+    })
+  })
+})

--- a/src/tests/unit/lib/utils/get-claims-display-info.test.ts
+++ b/src/tests/unit/lib/utils/get-claims-display-info.test.ts
@@ -159,4 +159,23 @@ describe('getClaimsDisplayInfo', () => {
       userAvatar: undefined,
     })
   })
+
+  it("falls back to 'User' when full_name is non-string and email is missing", () => {
+    // Arrange
+    // Defends the worst-case shape: malformed JWT with a non-string full_name
+    // claim and no email field. The header must still render a stable string.
+    const claims: SupabaseClaims = {
+      ...baseClaims,
+      user_metadata: { full_name: { nested: 'object' } },
+    }
+
+    // Act
+    const result = getClaimsDisplayInfo(claims)
+
+    // Assert
+    expect(result).toEqual({
+      userName: 'User',
+      userAvatar: undefined,
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- /board/[id] layout's auth gate switches from `auth.getUser()` (~50ms GoTrue round-trip Vercel `bom1` → Supabase `ap-south-1`) to `requireClaims()` (~5ms local WebCrypto verify).
- Header `userName` / `userAvatar` now come from JWT claims via a new `getClaimsDisplayInfo` util in `src/lib/utils/`.
- Unblocks `loading.tsx` Skeleton: the layout's auth wait was the dominant cost on the streaming critical path; first byte → Skeleton paint becomes effectively immediate.

This is PR #2 of 3 from `plans/2026-05-21_board_ttfb_reduction.md` (Fix 2). PR #1 (Fix 1 + Fix 3) landed as #195. PR #3 (Fix 4 — Supabase region migration) follows.

## Behavior notes (intentional)

- `getClaimsDisplayInfo` narrows `user_metadata.full_name` / `avatar_url` with `typeof === 'string'` before use. Previously a truthy non-string (e.g. number from a misshaped `user_metadata`) would have rendered as `userName`. In practice GitHub OAuth populates these as strings so user-visible behavior is unchanged — but the type narrowing is deliberate, since `SupabaseClaims.user_metadata` is typed `Record<string, unknown>`.
- Empty-string `full_name` still falls through to `email` then `'User'` via the `||` cascade — covered by a dedicated test.

## /review findings (2026-05-21)

Ran `/review` with 4 specialists + Claude/Codex adversarial passes. **AUTO-FIX applied** for the only mechanical gap; remaining 4 findings are **SUPPRESS — already-accepted design decisions documented in the plan or prior commits**.

| Finding | Severity | Disposition | Rationale |
|---|---|---|---|
| Edge case: non-string `full_name` + missing `email` → `'User'` | Testing / mechanical | **AUTO-FIX (commit `3881386`)** | Added 8th DAMP/AAA case to `get-claims-display-info.test.ts` |
| `/board/*` no longer hits live Auth `/user` endpoint → session revocation delayed up to JWT `exp` (~1h) | Codex HIGH | **SUPPRESS** | Same tradeoff already accepted across 11 call sites in commit `0589e9c` (PR #195). PR #196 extends the same pattern — does not introduce a new vulnerability. JWT `exp` is short; revocation window is bounded. |
| Test plan T1.4 calls for `user_name → preferred_username → email` chain | Testing CRITICAL | **SUPPRESS** | Neither original code nor migrated code implements this chain; T1.4 is aspirational. Per plan D3 (narrow scope), `getClaimsDisplayInfo` preserves the original `full_name || email || 'User'` cascade. Field-precedence work belongs to a separate scope review, not this perf PR. |
| `getClaimsDisplayInfo` duplicates a similar pattern in sibling layouts | Maintainability INFO | **SUPPRESS** | Intentional per plan D3 — only `src/app/board/layout.tsx` migrates in PR #2. Sibling layouts (`/boards`, `/boards/favorites`, `/boards/new`, `/maintenance`) still use `getUser()`; consolidation can happen after they migrate. |
| Test asserts empty-string `full_name → 'User'` but impl returns `'User'` correctly | Testing INFO | **SUPPRESS (duplicate)** | Duplicate of the T1.4 finding above; covered by the existing empty-string test. |

## Test plan

### Automated
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (max-warnings 0)
- [x] `pnpm test` — 1362/1362 pass, includes new 8 cases for `getClaimsDisplayInfo`
- [x] `pnpm build` succeeds
- [x] `pnpm e2e:parallel` — 12/12 shards green

### Not testable in CI (documented gaps from the task plan)
- **T2-T2 Skeleton paint <200ms** — MSW collapses Supabase latency to ~0ms in E2E, so the Skeleton flash isn't observable in our test environment. Manual verification owed.
- **T2-T3 unauthenticated → /login redirect** — `src/lib/supabase/server.ts:155-175` hardcodes a valid mock `getClaims()` response when `APP_ENV=test`. The redirect path through `requireClaims` → `getCachedClaims` → `redirect('/login')` is already covered by the existing unit tests on `require-claims` / `get-cached-claims` (which mock the SDK return directly), so the runtime redirect is exercised — just not as an end-to-end Playwright flow.

### Manual follow-up (post-merge)
- [ ] Measure /board/[id] TTFB + Skeleton paint from a Tokyo IP and compare against pre-PR baseline captured in `plans/2026-05-21_board_ttfb_reduction.md`. Expected: layout completes in ~5ms (vs ~50ms), Skeleton renders effectively instantaneously after first byte.

## Scope (per plan D3)

This PR migrates **only** `src/app/board/layout.tsx`. The other 4 protected layouts (`/boards`, `/boards/favorites`, `/boards/new`, `/maintenance`) intentionally still use `getUser()` and will be migrated in follow-up PRs once this one bakes — same one-layout-at-a-time discipline as PR #195.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Board layout authentication now uses JWT claim verification enabling earlier streaming and faster page rendering.
  * Centralized user display info extraction to improve name/avatar fallbacks and robustness.

* **Tests**
  * Added comprehensive unit tests for display-info extraction covering fallbacks and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/gitbox/pull/196?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->