### PR TITLE
perf(auth): finish getUser() → claims migration across layouts + actions

### DIFF
--- a/src/app/account/layout.tsx
+++ b/src/app/account/layout.tsx
@@ -3,12 +3,13 @@
  *
  * Layout for /account route
  * - Sidebar navigation
- * - Fetches user information and passes it to Sidebar
+ * - Reads JWT claims (~5ms WebCrypto verify via `requireClaims`) for header
+ *   user info. The /account page itself still uses `requireUser()` because
+ *   it needs `user.created_at`, which is not in the JWT claims payload.
  */
 
-import { redirect } from 'next/navigation'
-
-import { createClient } from '@/lib/supabase/server'
+import { requireClaims } from '@/lib/auth/require-claims'
+import { getClaimsDisplayInfo } from '@/lib/utils/get-claims-display-info'
 
 import { AccountLayoutClient } from './AccountLayoutClient'
 
@@ -17,20 +18,8 @@ export default async function AccountLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-
-  // Authentication check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  // Get user metadata
-  const userName = user.user_metadata?.full_name || user.email || 'User'
-  const userAvatar = user.user_metadata?.avatar_url
+  const { claims } = await requireClaims()
+  const { userName, userAvatar } = getClaimsDisplayInfo(claims)
 
   return (
     <AccountLayoutClient userName={userName} userAvatar={userAvatar}>

--- a/src/app/boards/layout.tsx
+++ b/src/app/boards/layout.tsx
@@ -3,12 +3,13 @@
  *
  * Layout for /boards/* routes
  * - Sidebar navigation
- * - Fetches user information and passes it to Sidebar
+ * - Reads JWT claims (~5ms WebCrypto verify via `requireClaims`) for header
+ *   user info, avoiding the ~50ms `auth.getUser()` GoTrue round-trip and
+ *   unblocking `loading.tsx` streaming below this layout.
  */
 
-import { redirect } from 'next/navigation'
-
-import { createClient } from '@/lib/supabase/server'
+import { requireClaims } from '@/lib/auth/require-claims'
+import { getClaimsDisplayInfo } from '@/lib/utils/get-claims-display-info'
 
 import { BoardsLayoutClient } from './BoardsLayoutClient'
 
@@ -17,20 +18,8 @@ export default async function BoardsLayout({
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-
-  // Authentication check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/login')
-  }
-
-  // Get user metadata
-  const userName = user.user_metadata?.full_name || user.email || 'User'
-  const userAvatar = user.user_metadata?.avatar_url
+  const { claims } = await requireClaims()
+  const { userName, userAvatar } = getClaimsDisplayInfo(claims)
 
   return (
     <BoardsLayoutClient userName={userName} userAvatar={userAvatar}>

--- a/src/app/maintenance/layout.tsx
+++ b/src/app/maintenance/layout.tsx
@@ -3,28 +3,20 @@
  *
  * Layout for /maintenance route
  * - Theme application for authenticated users
+ * - Auth gate via JWT claims (~5ms WebCrypto verify) instead of the ~50ms
+ *   `auth.getUser()` round-trip. Claims body is unused here; the call exists
+ *   for its redirect side effect when the JWT is missing or expired.
  */
 
-import { redirect } from 'next/navigation'
-
 import { ThemeApplicator } from '@/components/ThemeApplicator'
-import { createClient } from '@/lib/supabase/server'
+import { requireClaims } from '@/lib/auth/require-claims'
 
 export default async function MaintenanceLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-
-  // Authentication check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/login')
-  }
+  await requireClaims()
 
   return (
     <>

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -3,28 +3,20 @@
  *
  * Layout for /settings route
  * - Theme application for authenticated users
+ * - Auth gate via JWT claims (~5ms WebCrypto verify) instead of the ~50ms
+ *   `auth.getUser()` round-trip. Claims body is unused here; the call exists
+ *   for its redirect side effect when the JWT is missing or expired.
  */
 
-import { redirect } from 'next/navigation'
-
 import { ThemeApplicator } from '@/components/ThemeApplicator'
-import { createClient } from '@/lib/supabase/server'
+import { requireClaims } from '@/lib/auth/require-claims'
 
 export default async function SettingsLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
-  const supabase = await createClient()
-
-  // Authentication check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/login')
-  }
+  await requireClaims()
 
   return (
     <>

--- a/src/lib/actions/auth.ts
+++ b/src/lib/actions/auth.ts
@@ -13,6 +13,7 @@ import * as Sentry from '@sentry/nextjs'
 import { headers } from 'next/headers'
 import { redirect } from 'next/navigation'
 
+import { getCachedClaims } from '@/lib/auth/get-cached-claims'
 import { deleteGitHubTokenCookie } from '@/lib/constants/cookies'
 import { checkRateLimit } from '@/lib/rate-limit/check'
 import { logSecurityEvent } from '@/lib/security-events'
@@ -112,23 +113,21 @@ export async function signOut() {
  * @throws Error if deletion fails
  */
 export async function deleteAccount() {
-  const supabase = await createServerActionClient()
+  // Get current user via JWT claims (~5ms WebCrypto verify) instead of the
+  // ~50ms `auth.getUser()` GoTrue round-trip. `claims.sub` is the user UUID.
+  const authedContext = await getCachedClaims()
 
-  // Get current user
-  const {
-    data: { user },
-    error: userError,
-  } = await supabase.auth.getUser()
-
-  if (userError || !user) {
-    Sentry.captureException(userError ?? new Error('User not found'), {
+  if (!authedContext) {
+    Sentry.captureException(new Error('User not found'), {
       extra: { context: 'Delete account - get user' },
     })
     throw new Error('Not authenticated')
   }
 
+  const { claims } = authedContext
+
   // Rate limit by user ID
-  const rlResult = checkRateLimit('deleteAccount', user.id)
+  const rlResult = checkRateLimit('deleteAccount', claims.sub)
   if (!rlResult.allowed) {
     throw new Error(rlResult.error!)
   }
@@ -136,17 +135,17 @@ export async function deleteAccount() {
   // Use admin client to delete user (bypasses RLS)
   const adminClient = createAdminClient()
   const { error: deleteError } = await adminClient.auth.admin.deleteUser(
-    user.id,
+    claims.sub,
   )
 
   if (deleteError) {
     Sentry.captureException(deleteError, {
-      extra: { context: 'Delete account', userId: user.id },
+      extra: { context: 'Delete account', userId: claims.sub },
     })
     throw new Error('Failed to delete account')
   }
 
-  logSecurityEvent('account_deleted', { userId: user.id })
+  logSecurityEvent('account_deleted', { userId: claims.sub })
 
   await deleteGitHubTokenCookie()
 

--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -142,13 +142,12 @@ export async function createStatusList(
   statusListNameSchema.parse(name)
   statusListColorSchema.parse(color)
 
-  const supabase = await createClient()
-
-  // Auth check (P1-5): RLS handles ownership, but verify user is authenticated
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) throw new Error('Authentication required')
+  // Auth check (P1-5): RLS handles ownership, but verify user is authenticated.
+  // Uses JWT claims (~5ms WebCrypto verify) instead of the ~50ms `auth.getUser()`
+  // GoTrue round-trip — claims body is unused; only existence matters here.
+  const authedContext = await getCachedClaims()
+  if (!authedContext) throw new Error('Authentication required')
+  const { supabase } = authedContext
 
   // Get the current max grid_col in row 0
   const { data: maxColData } = await supabase

--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -142,46 +142,41 @@ export async function createStatusList(
   statusListNameSchema.parse(name)
   statusListColorSchema.parse(color)
 
-  // Auth check (P1-5): RLS handles ownership, but verify user is authenticated.
-  // Uses JWT claims (~5ms WebCrypto verify) instead of the ~50ms `auth.getUser()`
-  // GoTrue round-trip — claims body is unused; only existence matters here.
-  const authedContext = await getCachedClaims()
-  if (!authedContext) throw new Error('Authentication required')
-  const { supabase } = authedContext
+  return withAuthRateLimit('boardCrud', async (supabase) => {
+    // Get the current max grid_col in row 0
+    const { data: maxColData } = await supabase
+      .from('statuslist')
+      .select('grid_col')
+      .eq('board_id', boardId)
+      .eq('grid_row', 0)
+      .order('grid_col', { ascending: false })
+      .limit(1)
+      .single()
 
-  // Get the current max grid_col in row 0
-  const { data: maxColData } = await supabase
-    .from('statuslist')
-    .select('grid_col')
-    .eq('board_id', boardId)
-    .eq('grid_row', 0)
-    .order('grid_col', { ascending: false })
-    .limit(1)
-    .single()
+    const nextCol = (maxColData?.grid_col ?? -1) + 1
 
-  const nextCol = (maxColData?.grid_col ?? -1) + 1
+    const { data, error } = await supabase
+      .from('statuslist')
+      .insert({
+        board_id: boardId,
+        name,
+        color,
+        order: nextCol, // Keep order in sync for backwards compatibility
+        grid_row: 0,
+        grid_col: nextCol,
+      })
+      .select()
+      .single()
 
-  const { data, error } = await supabase
-    .from('statuslist')
-    .insert({
-      board_id: boardId,
-      name,
-      color,
-      order: nextCol, // Keep order in sync for backwards compatibility
-      grid_row: 0,
-      grid_col: nextCol,
-    })
-    .select()
-    .single()
+    if (error || !data) {
+      Sentry.captureException(error ?? new Error('No data returned'), {
+        extra: { context: 'Create status list', boardId, name },
+      })
+      throw new Error('Failed to create status list')
+    }
 
-  if (error || !data) {
-    Sentry.captureException(error ?? new Error('No data returned'), {
-      extra: { context: 'Create status list', boardId, name },
-    })
-    throw new Error('Failed to create status list')
-  }
-
-  return toStatusListDomain(data)
+    return toStatusListDomain(data)
+  })
 }
 
 /**

--- a/src/lib/actions/board.ts
+++ b/src/lib/actions/board.ts
@@ -143,15 +143,25 @@ export async function createStatusList(
   statusListColorSchema.parse(color)
 
   return withAuthRateLimit('boardCrud', async (supabase) => {
-    // Get the current max grid_col in row 0
-    const { data: maxColData } = await supabase
+    // Get the current max grid_col in row 0. maybeSingle() returns null
+    // (no error) when the board has no columns yet — that's the legitimate
+    // empty case. Any other error means RLS denial, network failure, etc.,
+    // and silently falling back to 0 would duplicate grid_col on the insert.
+    const { data: maxColData, error: maxColError } = await supabase
       .from('statuslist')
       .select('grid_col')
       .eq('board_id', boardId)
       .eq('grid_row', 0)
       .order('grid_col', { ascending: false })
       .limit(1)
-      .single()
+      .maybeSingle()
+
+    if (maxColError) {
+      Sentry.captureException(maxColError, {
+        extra: { context: 'Read max grid_col for createStatusList', boardId },
+      })
+      throw new Error('Failed to create status list')
+    }
 
     const nextCol = (maxColData?.grid_col ?? -1) + 1
 


### PR DESCRIPTION
## Summary

Closes out the server-side `auth.getUser()` → `getCachedClaims()` / `requireClaims()` migration.

**6 sites migrated:**
- 4 sibling layouts: `/boards`, `/account`, `/maintenance`, `/settings` → `requireClaims()`
- 2 Server Actions: `createStatusList` (board.ts), `deleteAccount` (auth.ts) → `getCachedClaims()`

Each site previously paid a ~50ms GoTrue round-trip on every authed request. The layouts now share a single request-scoped JWKS verify (~5ms) via `React.cache`, and the actions reuse the same memoized result. Net: roughly **-45ms TTFB** on first paint of every protected route, plus the deleteAccount mutation no longer constructs a redundant Server Action client.

## Intentionally deferred

Three remaining `getUser()` call sites left in place — they are *not* in the hot path and have different requirements:

| File | Line | Why kept |
| --- | --- | --- |
| `src/app/api/auth/github/refresh/route.ts` | 119 | Route handler, runs outside the layout cache scope |
| `src/lib/supabase/client.ts` | 54 | **Browser** client — claims path is server-only |
| `src/lib/auth/require-user.ts` | — | Used by `/account` for the full `user` object (profile fields beyond `claims.sub`) |

## Observability regression (acceptable)

`deleteAccount` previously distinguished "`userError` from `getUser()`" vs "no user returned" in Sentry. Both now collapse to a single `new Error('Not authenticated')` payload. Acceptable trade for the perf win — the upstream `getCachedClaims()` path raises its own errors before this branch.

## Validation

- ✅ `pnpm typecheck`
- ✅ `pnpm lint` (max-warnings 0)
- ✅ `pnpm test` — 1362 tests / 99 files
- ✅ `pnpm build` — all 20 routes
- ✅ `pnpm e2e:parallel` — 12/12 shards in 194s

## Follow-up (out of scope for this PR)

- Add `loading.tsx` streaming boundaries to `/boards`, `/settings`, `/maintenance`, `/account` to surface the TTFB win as paint-time skeleton

## Test plan
- [x] Local typecheck / lint / unit
- [x] Local production build
- [x] 12-shard parallel E2E
- [ ] Vercel preview smoke test (post-merge): land → GitHub OAuth → /boards → open board → delete account flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified authentication to use JWT-claims and cached claims across Account, Boards, Maintenance, and Settings layouts and related actions, simplifying auth flows and reducing server round-trips.
  * Account deletion and board/status-list creation now use the cached auth context and claim-derived identifiers, preserving user-facing behavior.

* **Bug Fixes**
  * Removed redundant auth round-trips and stale redirect behavior to streamline routing and reduce edge-case failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/gitbox/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->