### PR TITLE
fix(boards): eliminate theme FOUC via head-injected init script

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,11 +18,23 @@ import { Toaster } from 'sonner'
 
 import { CommandPalette } from '@/components/CommandPalette/CommandPalette'
 import { ShortcutsHelp } from '@/components/ShortcutsHelp'
+import { DARK_THEME_IDS } from '@/lib/constants/themes'
 import { ReduxProvider } from '@/lib/redux/reduxProvider'
 import { isMSWEnabled } from '@/lib/utils/isMSWEnabled'
 import '@/styles/globals.css'
 
 import { MSWProvider } from './msw-provider'
+
+// Inline script injected into <head> to apply the persisted theme BEFORE
+// React hydrates. Without this, the default light theme paints first, then
+// `<ThemeApplicator />` swaps to the user's chosen theme after mount —
+// causing a visible FOUC (white → dark theme) on every navigation.
+// Reads the same `gitbox-state` key used by @laststance/redux-storage-middleware
+// (shape: { version: 0, state: { settings: { theme } } }) and applies the
+// `data-theme` attribute + `.dark` class directly to <html> synchronously.
+// `suppressHydrationWarning` on <html> covers React re-applying the same
+// attributes after hydration (idempotent — no visible change).
+const themeInitScript = `(function(){try{var raw=localStorage.getItem('gitbox-state');var theme;if(raw){var parsed=JSON.parse(raw);theme=parsed&&parsed.state&&parsed.state.settings&&parsed.state.settings.theme;}var root=document.documentElement;if(!theme||theme==='system'){var prefersDark=window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches;root.classList.toggle('dark',prefersDark);return;}var darkThemes=${JSON.stringify(DARK_THEME_IDS)};root.setAttribute('data-theme',theme);root.classList.toggle('dark',darkThemes.indexOf(theme)!==-1);}catch(e){}})();`
 
 /**
  * Metadata Configuration
@@ -83,7 +95,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <head></head>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="antialiased">
         <NextTopLoader
           color="oklch(0.696 0.17 162.48)"

--- a/src/hooks/use-storage-hydrated.ts
+++ b/src/hooks/use-storage-hydrated.ts
@@ -1,0 +1,53 @@
+/**
+ * Storage Hydration Hook
+ *
+ * Subscribes to the redux-storage-middleware hydration status so React
+ * components can defer DOM effects until persisted state has been loaded
+ * from localStorage. Without this, effects like `useTheme` would briefly
+ * apply the initial Redux state (e.g. `theme: 'system'`) before
+ * `ACTION_HYDRATE_COMPLETE` swaps in the user's saved value — causing a
+ * visible flash on first render.
+ *
+ * Uses `useSyncExternalStore` so the value is correct on both SSR (always
+ * `false`) and client (initial `false`, flips to `true` post-rehydrate).
+ */
+
+import { useSyncExternalStore } from 'react'
+
+import { storageApi } from '@/lib/redux/store'
+
+/**
+ * Subscribes the React component to storage hydration completion.
+ * Used by `useSyncExternalStore` — fires `onChange` exactly once when
+ * hydration finishes. Returns a cleanup that removes the subscription.
+ */
+const subscribeToHydration = (onChange: () => void): (() => void) => {
+  return storageApi.onFinishHydration(() => {
+    onChange()
+  })
+}
+
+const getClientSnapshot = (): boolean => storageApi.hasHydrated()
+
+const getServerSnapshot = (): boolean => false
+
+/**
+ * Returns `true` once redux-storage-middleware has finished restoring
+ * persisted slices from localStorage.
+ *
+ * @returns Hydration status — `false` during SSR and pre-hydrate client
+ *   renders, `true` after `ACTION_HYDRATE_COMPLETE` fires.
+ * @example
+ * const hasHydrated = useStorageHydrated()
+ * useEffect(() => {
+ *   if (!hasHydrated) return
+ *   // Safe to read persisted Redux state and apply to DOM
+ * }, [hasHydrated, themeFromRedux])
+ */
+export function useStorageHydrated(): boolean {
+  return useSyncExternalStore(
+    subscribeToHydration,
+    getClientSnapshot,
+    getServerSnapshot,
+  )
+}

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -11,6 +11,7 @@
 import { useCallback, useEffect } from 'react'
 
 import { useMounted } from '@/hooks/use-mounted'
+import { useStorageHydrated } from '@/hooks/use-storage-hydrated'
 import {
   type ThemeType,
   ALL_THEMES,
@@ -38,26 +39,32 @@ export { ALL_THEMES, LIGHT_THEMES, DARK_THEMES, isDarkTheme }
  */
 export function useTheme() {
   const mounted = useMounted()
+  // Gate DOM effects on localStorage hydration — without this, the initial
+  // Redux state (`theme: 'system'`) would briefly overwrite the value the
+  // <head> inline script applied for the user's saved theme, causing a FOUC.
+  const hasHydrated = useStorageHydrated()
 
   const dispatch = useAppDispatch()
   const theme = useAppSelector(selectTheme)
 
   // Apply theme to document
   useEffect(() => {
-    if (!mounted) return
+    if (!mounted || !hasHydrated) return
 
     const root = document.documentElement
-    root.removeAttribute('data-theme')
 
     let shouldBeDark: boolean
     if (theme === 'system') {
+      // Only clear data-theme when switching INTO system — leaving it untouched
+      // otherwise preserves the value set by the <head> inline anti-FOUC script.
+      root.removeAttribute('data-theme')
       shouldBeDark = window.matchMedia('(prefers-color-scheme: dark)').matches
     } else {
       root.setAttribute('data-theme', theme)
       shouldBeDark = isDarkTheme(theme)
     }
     root.classList.toggle('dark', shouldBeDark)
-  }, [theme, mounted])
+  }, [theme, mounted, hasHydrated])
 
   const setTheme = useCallback(
     (newTheme: ThemeType) => {

--- a/src/lib/redux/store.ts
+++ b/src/lib/redux/store.ts
@@ -27,12 +27,20 @@ const rootReducer = combineReducers({
 
 // Storage middleware configuration with new API
 // Returns hydration-wrapped reducer automatically
-const { middleware: storageMiddleware, reducer: hydratedReducer } =
-  createStorageMiddleware({
-    rootReducer, // Required: pass root reducer
-    key: 'gitbox-state',
-    slices: ['settings', 'board', 'draft'], // Persist these slices to localStorage
-  })
+const {
+  middleware: storageMiddleware,
+  reducer: hydratedReducer,
+  api: storageApi,
+} = createStorageMiddleware({
+  rootReducer, // Required: pass root reducer
+  key: 'gitbox-state',
+  slices: ['settings', 'board', 'draft'], // Persist these slices to localStorage
+})
+
+// Exposed so hooks (e.g. useTheme) can gate effects on localStorage hydration
+// completion — avoids transient "initial Redux state" values being applied to
+// the DOM in the microtask window before `ACTION_HYDRATE_COMPLETE` fires.
+export { storageApi }
 
 export const store = configureStore({
   // Use returned reducer (already hydration-wrapped)


### PR DESCRIPTION
## Summary

- ハイドレーション前にテーマフラッシュ(FOUC)が出る不具合を解消
- `<head>` 内のインラインスクリプトで localStorage 永続化された theme を最初の paint 前に適用
- `useTheme` の `useEffect` を storage hydration 完了までゲート

## Background

`/boards` 等のページに遷移するたび、保存済みのダーク系テーマ(midnight, dark, forest など)に対して

1. SSR が `<html>` を素の状態で返す
2. 初回 paint がデフォルトライトテーマで描画
3. React hydration → Redux 初期化 (`theme: 'system'`) → `useTheme useEffect` → ようやくユーザーのテーマ適用

という順序になり、白 → 暗色のフラッシュが視認できる状態でした。

## Approach

next-themes と同様の業界標準パターン:

1. `src/app/layout.tsx` の `<head>` 内に同期実行されるインラインスクリプトを注入
   - `gitbox-state` localStorage キー(`@laststance/redux-storage-middleware` が使用)を読む
   - `data-theme` attribute と `.dark` class を `<html>` に同期適用
   - CSP は Report-Only モードかつ `script-src 'unsafe-inline'` 許可済みなのでブロックされない
2. `useTheme` の effect を `useStorageHydrated()` でゲート
   - 初期 Redux state (`theme: 'system'`) がインラインスクリプト適用済みの値を上書きしないように
3. `root.removeAttribute('data-theme')` を `theme === 'system'` 分岐内に移動
   - system 以外への切替時はインラインスクリプトの設定値を尊重

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 99 files / 1362 tests passed (useTheme 29 tests も合格)
- [x] `pnpm build` — production build success
- [x] `pnpm e2e:parallel` — 12/12 shards passed
- [x] chrome-devtools MCP で手動確認:
  - 空の localStorage + `prefers-color-scheme: dark` → 即座に `.dark` class 付与
  - localStorage `theme: 'midnight'` → `data-theme="midnight"` + `.dark` class が paint 前に適用
  - `/boards` → `/login` リダイレクト後もテーマ保持
- [x] 本番ビルド (`pnpm start`) で HTML に inline script が SSR されることを curl で確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated theme flash during page navigation and initial load by applying theme preferences synchronously before React renders, ensuring a seamless visual experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/gitbox/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->